### PR TITLE
Add Nix expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ subprojects/*
 # Helper for bear (b-ear)
 compile_commands.json
 
+# direnv configuration file
+.envrc

--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ $ ninja -C build/ check               (optional, run unit tests)
 # ninja -C build/ install             (as a suitably-privileged user)
 ```
 
+## With Nix
+
+When [Nix](http://nixos.org/nix) is installed, then you don't need to manually install any
+dependencies.
+`libdjinterop` can then simply be built with:
+
+```
+$ nix build
+```
+
+In order to drop into a development environment with dependencies available, execute:
+
+```
+$ nix-shell
+```
+
+You can then build `libdjinterop` by using Meson as described above.
+This is advantageous when developing since it only recompiles sources that it needs to.
+
 Thanks To
 =========
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,47 @@
+with import <nixpkgs> {};
+
+let
+
+  git-clang-format = stdenv.mkDerivation {
+    name = "git-clang-format";
+    version = "2019-06-21";
+    src = fetchurl {
+      url = "https://raw.githubusercontent.com/llvm-mirror/clang/2bb8e0fe002e8ffaa9ce5fa58034453c94c7e208/tools/clang-format/git-clang-format";
+      sha256 = "1kby36i80js6rwi11v3ny4bqsi6i44b9yzs23pdcn9wswffx1nlf";
+      executable = true;
+    };
+    nativeBuildInputs = [
+      makeWrapper
+    ];
+    buildInputs = [
+      clang-tools
+      python3
+    ];
+    unpackPhase = ":";
+    installPhase = ''
+      mkdir -p $out/opt $out/bin
+      cp $src $out/opt/git-clang-format
+      makeWrapper $out/opt/git-clang-format $out/bin/git-clang-format \
+        --add-flags --binary \
+        --add-flags ${clang-tools}/bin/clang-format
+    '';
+  };
+
+in
+
+stdenv.mkDerivation {
+  name = "libdjinterop";
+  version = "unstable";
+  src = nix-gitignore.gitignoreSource [ ".git*" ] ./.;
+  nativeBuildInputs = [
+    git-clang-format
+    meson
+    ninja
+    pkg-config
+  ];
+  outputs = [ "out" "dev" ];
+  buildInputs = [
+    boost
+    zlib
+  ];
+}


### PR DESCRIPTION
For those having [Nix](http://nixos.org/nix) installed, the Nix expression (contained in the new file `default.nix`) can be used

* with `nix-shell` in order to obtain a development environment for `libdjinterop`. Example:

  ```
  $ nix-shell
  $ meson build/
  $ ninja -C build/
  ```

* with `nix build` in order to build and check `libdjinterop` in one single command.