### PR TITLE
Remove internal use of Boost Optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,6 @@ project(
     default_options: ['cpp_std=c++17', 'default_library=both'])
 
 cpp_compiler = meson.get_compiler('cpp')
-add_global_arguments('-D_MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT', language: 'cpp')
 if cpp_compiler.get_id() == 'msvc'
     # Ask MSVC to populate the __cplusplus macro properly.
     add_global_arguments('/Zc:__cplusplus', language: 'cpp')

--- a/src/djinterop/crate.cpp
+++ b/src/djinterop/crate.cpp
@@ -82,7 +82,7 @@ std::string crate::name() const
 
 std::optional<crate> crate::parent() const
 {
-    return from_boost_optional(pimpl_->parent());
+    return pimpl_->parent();
 }
 
 void crate::remove_track(track tr) const
@@ -97,13 +97,13 @@ void crate::set_name(std::string name) const
 
 void crate::set_parent(std::optional<crate> parent) const
 {
-    pimpl_->set_parent(to_boost_optional(parent));
+    pimpl_->set_parent(parent);
 }
 
 std::optional<crate> crate::sub_crate_by_name(
     const std::string& name) const
 {
-    return from_boost_optional(pimpl_->sub_crate_by_name(name));
+    return pimpl_->sub_crate_by_name(name);
 }
 
 std::vector<track> crate::tracks() const

--- a/src/djinterop/database.cpp
+++ b/src/djinterop/database.cpp
@@ -39,7 +39,7 @@ transaction_guard database::begin_transaction() const
 
 std::optional<crate> database::crate_by_id(int64_t id) const
 {
-    return from_boost_optional(pimpl_->crate_by_id(id));
+    return pimpl_->crate_by_id(id);
 }
 
 std::vector<crate> database::crates() const
@@ -95,12 +95,12 @@ std::vector<crate> database::root_crates() const
 std::optional<crate> database::root_crate_by_name(
     const std::string& name) const
 {
-    return from_boost_optional(pimpl_->root_crate_by_name(name));
+    return pimpl_->root_crate_by_name(name);
 }
 
 std::optional<track> database::track_by_id(int64_t id) const
 {
-    return from_boost_optional(pimpl_->track_by_id(id));
+    return pimpl_->track_by_id(id);
 }
 
 std::vector<track> database::tracks() const

--- a/src/djinterop/enginelibrary/el_crate_impl.cpp
+++ b/src/djinterop/enginelibrary/el_crate_impl.cpp
@@ -211,7 +211,7 @@ bool el_crate_impl::is_valid()
 
 std::string el_crate_impl::name()
 {
-    boost::optional<std::string> name;
+    std::optional<std::string> name;
     storage_->db << "SELECT title FROM Crate WHERE id = ?" << id() >>
         [&](std::string title) {
             if (!name)
@@ -231,9 +231,9 @@ std::string el_crate_impl::name()
     return *name;
 }
 
-boost::optional<crate> el_crate_impl::parent()
+std::optional<crate> el_crate_impl::parent()
 {
-    boost::optional<crate> parent;
+    std::optional<crate> parent;
     storage_->db
             << "SELECT crateParentId FROM CrateParentList WHERE crateOriginId "
                "= ? AND crateParentId <> crateOriginId"
@@ -298,7 +298,7 @@ void el_crate_impl::set_name(std::string name)
     trans.commit();
 }
 
-void el_crate_impl::set_parent(boost::optional<crate> parent)
+void el_crate_impl::set_parent(std::optional<crate> parent)
 {
     el_transaction_guard_impl trans{storage_};
 
@@ -323,9 +323,9 @@ void el_crate_impl::set_parent(boost::optional<crate> parent)
     trans.commit();
 }
 
-boost::optional<crate> el_crate_impl::sub_crate_by_name(const std::string& name)
+std::optional<crate> el_crate_impl::sub_crate_by_name(const std::string& name)
 {
-    boost::optional<crate> cr;
+    std::optional<crate> cr;
     storage_->db << "SELECT cr.id FROM Crate cr "
                     "JOIN CrateParentList cpl ON (cpl.crateOriginId = cr.id) "
                     "WHERE cr.title = ? "

--- a/src/djinterop/enginelibrary/el_crate_impl.hpp
+++ b/src/djinterop/enginelibrary/el_crate_impl.hpp
@@ -41,11 +41,11 @@ public:
     std::vector<crate> descendants() override;
     bool is_valid() override;
     std::string name() override;
-    boost::optional<crate> parent() override;
+    std::optional<crate> parent() override;
     void remove_track(track tr) override;
     void set_name(std::string name) override;
-    void set_parent(boost::optional<crate> parent) override;
-    boost::optional<crate> sub_crate_by_name(const std::string& name) override;
+    void set_parent(std::optional<crate> parent) override;
+    std::optional<crate> sub_crate_by_name(const std::string& name) override;
     std::vector<track> tracks() override;
 
 private:

--- a/src/djinterop/enginelibrary/el_database_impl.cpp
+++ b/src/djinterop/enginelibrary/el_database_impl.cpp
@@ -70,9 +70,9 @@ transaction_guard el_database_impl::begin_transaction()
         std::make_unique<el_transaction_guard_impl>(storage_)};
 }
 
-boost::optional<crate> el_database_impl::crate_by_id(int64_t id)
+std::optional<crate> el_database_impl::crate_by_id(int64_t id)
 {
-    boost::optional<crate> cr;
+    std::optional<crate> cr;
     storage_->db << "SELECT COUNT(*) FROM Crate WHERE id = ?" << id >>
         [&](int64_t count) {
             if (count == 1)
@@ -162,7 +162,7 @@ track el_database_impl::create_track(std::string relative_path)
             << "REPLACE INTO MetaData (id, type, text) VALUES (?, ?, ?)";
         for (int64_t type : {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 16})
         {
-            boost::optional<std::string> text;
+            std::optional<std::string> text;
             switch (type)
             {
                 case 10:
@@ -193,7 +193,7 @@ track el_database_impl::create_track(std::string relative_path)
                                         "type, value) VALUES (?, ?, ?)";
         for (int64_t type = 1; type <= 11 /* 12 */; ++type)
         {
-            boost::optional<int64_t> value;
+            std::optional<int64_t> value;
             switch (type)
             {
                 case 5: value = 0; break;
@@ -258,9 +258,9 @@ std::vector<crate> el_database_impl::root_crates()
     return results;
 }
 
-boost::optional<crate> el_database_impl::root_crate_by_name(const std::string& name)
+std::optional<crate> el_database_impl::root_crate_by_name(const std::string& name)
 {
-    boost::optional<crate> cr;
+    std::optional<crate> cr;
     storage_->db << "SELECT cr.id FROM Crate cr "
                     "JOIN CrateParentList cpl ON (cpl.crateOriginId = cr.id) "
                     "WHERE cr.title = ? "
@@ -273,9 +273,9 @@ boost::optional<crate> el_database_impl::root_crate_by_name(const std::string& n
     return cr;
 }
 
-boost::optional<track> el_database_impl::track_by_id(int64_t id)
+std::optional<track> el_database_impl::track_by_id(int64_t id)
 {
-    boost::optional<track> tr;
+    std::optional<track> tr;
     storage_->db << "SELECT COUNT(*) FROM Track WHERE id = ?" << id >>
         [&](int64_t count) {
             if (count == 1)

--- a/src/djinterop/enginelibrary/el_database_impl.hpp
+++ b/src/djinterop/enginelibrary/el_database_impl.hpp
@@ -33,7 +33,7 @@ public:
     el_database_impl(std::shared_ptr<el_storage> storage);
 
     transaction_guard begin_transaction() override;
-    boost::optional<djinterop::crate> crate_by_id(int64_t id) override;
+    std::optional<djinterop::crate> crate_by_id(int64_t id) override;
     std::vector<djinterop::crate> crates() override;
     std::vector<djinterop::crate> crates_by_name(
         const std::string& name) override;
@@ -45,9 +45,9 @@ public:
     void remove_crate(djinterop::crate cr) override;
     void remove_track(djinterop::track tr) override;
     std::vector<djinterop::crate> root_crates() override;
-    boost::optional<djinterop::crate> root_crate_by_name(
+    std::optional<djinterop::crate> root_crate_by_name(
         const std::string& name) override;
-    boost::optional<djinterop::track> track_by_id(int64_t id) override;
+    std::optional<djinterop::track> track_by_id(int64_t id) override;
     std::vector<djinterop::track> tracks() override;
     std::vector<djinterop::track> tracks_by_relative_path(
         const std::string& relative_path) override;

--- a/src/djinterop/enginelibrary/el_track_impl.cpp
+++ b/src/djinterop/enginelibrary/el_track_impl.cpp
@@ -37,10 +37,10 @@ using std::chrono::system_clock;
 
 namespace
 {
-boost::optional<system_clock::time_point> to_time_point(
-    boost::optional<int64_t> timestamp)
+std::optional<system_clock::time_point> to_time_point(
+    std::optional<int64_t> timestamp)
 {
-    boost::optional<system_clock::time_point> result;
+    std::optional<system_clock::time_point> result;
     if (timestamp)
     {
         result = system_clock::time_point{seconds(*timestamp)};
@@ -48,10 +48,10 @@ boost::optional<system_clock::time_point> to_time_point(
     return result;
 }
 
-boost::optional<int64_t> to_timestamp(
-    boost::optional<system_clock::time_point> time)
+std::optional<int64_t> to_timestamp(
+    std::optional<system_clock::time_point> time)
 {
-    boost::optional<int64_t> result;
+    std::optional<int64_t> result;
     if (time)
     {
         result = duration_cast<seconds>(time->time_since_epoch()).count();
@@ -89,10 +89,10 @@ el_track_impl::el_track_impl(std::shared_ptr<el_storage> storage, int64_t id)
 {
 }
 
-boost::optional<std::string> el_track_impl::get_metadata_str(
+std::optional<std::string> el_track_impl::get_metadata_str(
     metadata_str_type type)
 {
-    boost::optional<std::string> result;
+    std::optional<std::string> result;
     storage_->db << "SELECT text FROM MetaData WHERE id = ? AND "
                     "type = ? AND text IS NOT NULL"
                  << id() << static_cast<int64_t>(type) >>
@@ -113,7 +113,7 @@ boost::optional<std::string> el_track_impl::get_metadata_str(
 }
 
 void el_track_impl::set_metadata_str(
-    metadata_str_type type, boost::optional<std::string> content)
+    metadata_str_type type, std::optional<std::string> content)
 {
     if (content)
     {
@@ -134,9 +134,9 @@ void el_track_impl::set_metadata_str(
                  << id() << static_cast<int64_t>(type) << content;
 }
 
-boost::optional<int64_t> el_track_impl::get_metadata_int(metadata_int_type type)
+std::optional<int64_t> el_track_impl::get_metadata_int(metadata_int_type type)
 {
-    boost::optional<int64_t> result;
+    std::optional<int64_t> result;
     storage_->db << "SELECT value FROM MetaDataInteger WHERE id = "
                     "? AND type = ? AND value IS NOT NULL"
                  << id() << static_cast<int64_t>(type) >>
@@ -157,7 +157,7 @@ boost::optional<int64_t> el_track_impl::get_metadata_int(metadata_int_type type)
 }
 
 void el_track_impl::set_metadata_int(
-    metadata_int_type type, boost::optional<int64_t> content)
+    metadata_int_type type, std::optional<int64_t> content)
 {
     storage_->db
         << "REPLACE INTO MetaDataInteger (id, type, value) VALUES (?, ?, ?)"
@@ -262,20 +262,20 @@ void el_track_impl::set_adjusted_main_cue(double sample_offset)
     trans.commit();
 }
 
-boost::optional<std::string> el_track_impl::album()
+std::optional<std::string> el_track_impl::album()
 {
     return get_metadata_str(metadata_str_type::album);
 }
 
-void el_track_impl::set_album(boost::optional<std::string> album)
+void el_track_impl::set_album(std::optional<std::string> album)
 {
     set_metadata_str(metadata_str_type::album, album);
 }
 
-boost::optional<int64_t> el_track_impl::album_art_id()
+std::optional<int64_t> el_track_impl::album_art_id()
 {
     int64_t cell = get_cell<int64_t>("idAlbumArt");
-    boost::optional<int64_t> album_art_id;
+    std::optional<int64_t> album_art_id;
     if (cell < 1)
     {
         // TODO (haslersn): Throw something.
@@ -287,7 +287,7 @@ boost::optional<int64_t> el_track_impl::album_art_id()
     return album_art_id;
 }
 
-void el_track_impl::set_album_art_id(boost::optional<int64_t> album_art_id)
+void el_track_impl::set_album_art_id(std::optional<int64_t> album_art_id)
 {
     if (album_art_id && *album_art_id <= 1)
     {
@@ -297,23 +297,23 @@ void el_track_impl::set_album_art_id(boost::optional<int64_t> album_art_id)
     // 1 is the magic number for "no album art"
 }
 
-boost::optional<std::string> el_track_impl::artist()
+std::optional<std::string> el_track_impl::artist()
 {
     return get_metadata_str(metadata_str_type::artist);
 }
 
-void el_track_impl::set_artist(boost::optional<std::string> artist)
+void el_track_impl::set_artist(std::optional<std::string> artist)
 {
     set_metadata_str(metadata_str_type::artist, artist);
 }
 
-boost::optional<double> el_track_impl::average_loudness()
+std::optional<double> el_track_impl::average_loudness()
 {
     return get_track_data().average_loudness;
 }
 
 void el_track_impl::set_average_loudness(
-    boost::optional<double> average_loudness)
+    std::optional<double> average_loudness)
 {
     el_transaction_guard_impl trans{storage_};
     auto track_d = get_track_data();
@@ -322,25 +322,25 @@ void el_track_impl::set_average_loudness(
     trans.commit();
 }
 
-boost::optional<int64_t> el_track_impl::bitrate()
+std::optional<int64_t> el_track_impl::bitrate()
 {
-    return get_cell<boost::optional<int64_t>>("bitrate");
+    return get_cell<std::optional<int64_t>>("bitrate");
 }
 
-void el_track_impl::set_bitrate(boost::optional<int64_t> bitrate)
+void el_track_impl::set_bitrate(std::optional<int64_t> bitrate)
 {
     set_cell("bitrate", bitrate);
 }
 
-boost::optional<double> el_track_impl::bpm()
+std::optional<double> el_track_impl::bpm()
 {
-    return get_cell<boost::optional<double>>("bpmAnalyzed");
+    return get_cell<std::optional<double>>("bpmAnalyzed");
 }
 
-void el_track_impl::set_bpm(boost::optional<double> bpm)
+void el_track_impl::set_bpm(std::optional<double> bpm)
 {
     set_cell("bpmAnalyzed", bpm);
-    boost::optional<int64_t> ceiled_bpm;
+    std::optional<int64_t> ceiled_bpm;
     if (bpm)
     {
         ceiled_bpm = static_cast<int64_t>(std::ceil(*bpm));
@@ -348,22 +348,22 @@ void el_track_impl::set_bpm(boost::optional<double> bpm)
     set_cell("bpm", ceiled_bpm);
 }
 
-boost::optional<std::string> el_track_impl::comment()
+std::optional<std::string> el_track_impl::comment()
 {
     return get_metadata_str(metadata_str_type::comment);
 }
 
-void el_track_impl::set_comment(boost::optional<std::string> comment)
+void el_track_impl::set_comment(std::optional<std::string> comment)
 {
     set_metadata_str(metadata_str_type::comment, comment);
 }
 
-boost::optional<std::string> el_track_impl::composer()
+std::optional<std::string> el_track_impl::composer()
 {
     return get_metadata_str(metadata_str_type::composer);
 }
 
-void el_track_impl::set_composer(boost::optional<std::string> composer)
+void el_track_impl::set_composer(std::optional<std::string> composer)
 {
     set_metadata_str(metadata_str_type::composer, composer);
 }
@@ -414,21 +414,21 @@ void el_track_impl::set_default_main_cue(double sample_offset)
     trans.commit();
 }
 
-boost::optional<milliseconds> el_track_impl::duration()
+std::optional<milliseconds> el_track_impl::duration()
 {
-    boost::optional<milliseconds> result;
+    std::optional<milliseconds> result;
     auto smp = sampling();
     if (smp)
     {
         double secs = smp->sample_count / smp->sample_rate;
         return milliseconds{static_cast<int64_t>(1000 * secs)};
     }
-    auto secs = get_cell<boost::optional<int64_t>>("length");
+    auto secs = get_cell<std::optional<int64_t>>("length");
     if (secs)
     {
         return milliseconds{*secs * 1000};
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 std::string el_track_impl::file_extension()
@@ -444,23 +444,23 @@ std::string el_track_impl::filename()
     return get_filename(rel_path);
 }
 
-boost::optional<std::string> el_track_impl::genre()
+std::optional<std::string> el_track_impl::genre()
 {
     return get_metadata_str(metadata_str_type::genre);
 }
 
-void el_track_impl::set_genre(boost::optional<std::string> genre)
+void el_track_impl::set_genre(std::optional<std::string> genre)
 {
     set_metadata_str(metadata_str_type::genre, genre);
 }
 
-boost::optional<hot_cue> el_track_impl::hot_cue_at(int32_t index)
+std::optional<hot_cue> el_track_impl::hot_cue_at(int32_t index)
 {
     auto quick_cues_d = get_quick_cues_data();
     return std::move(quick_cues_d.hot_cues[index]);
 }
 
-void el_track_impl::set_hot_cue_at(int32_t index, boost::optional<hot_cue> cue)
+void el_track_impl::set_hot_cue_at(int32_t index, std::optional<hot_cue> cue)
 {
     el_transaction_guard_impl trans{storage_};
     auto quick_cues_d = get_quick_cues_data();
@@ -469,13 +469,13 @@ void el_track_impl::set_hot_cue_at(int32_t index, boost::optional<hot_cue> cue)
     trans.commit();
 }
 
-std::array<boost::optional<hot_cue>, 8> el_track_impl::hot_cues()
+std::array<std::optional<hot_cue>, 8> el_track_impl::hot_cues()
 {
     auto quick_cues_d = get_quick_cues_data();
     return std::move(quick_cues_d.hot_cues);
 }
 
-void el_track_impl::set_hot_cues(std::array<boost::optional<hot_cue>, 8> cues)
+void el_track_impl::set_hot_cues(std::array<std::optional<hot_cue>, 8> cues)
 {
     el_transaction_guard_impl trans{storage_};
     // TODO (haslersn): The following can be optimized because in this case we
@@ -486,11 +486,11 @@ void el_track_impl::set_hot_cues(std::array<boost::optional<hot_cue>, 8> cues)
     trans.commit();
 }
 
-boost::optional<track_import_info> el_track_impl::import_info()
+std::optional<track_import_info> el_track_impl::import_info()
 {
     if (get_cell<int64_t>("isExternalTrack") == 0)
     {
-        return boost::none;
+        return std::nullopt;
     }
     return track_import_info{get_cell<std::string>("uuidOfExternalDatabase"),
                              get_cell<int64_t>("idTrackInExternalDatabase")};
@@ -499,7 +499,7 @@ boost::optional<track_import_info> el_track_impl::import_info()
 }
 
 void el_track_impl::set_import_info(
-    const boost::optional<track_import_info>& import_info)
+    const std::optional<track_import_info>& import_info)
 {
     if (import_info)
     {
@@ -533,9 +533,9 @@ bool el_track_impl::is_valid()
     return valid;
 }
 
-boost::optional<musical_key> el_track_impl::key()
+std::optional<musical_key> el_track_impl::key()
 {
-    boost::optional<musical_key> result;
+    std::optional<musical_key> result;
     auto key_num = get_metadata_int(metadata_int_type::musical_key);
     if (key_num)
     {
@@ -544,9 +544,9 @@ boost::optional<musical_key> el_track_impl::key()
     return result;
 }
 
-void el_track_impl::set_key(boost::optional<musical_key> key)
+void el_track_impl::set_key(std::optional<musical_key> key)
 {
-    boost::optional<int64_t> key_num;
+    std::optional<int64_t> key_num;
     if (key)
     {
         key_num = static_cast<int64_t>(*key);
@@ -560,7 +560,7 @@ void el_track_impl::set_key(boost::optional<musical_key> key)
     trans.commit();
 }
 
-boost::optional<system_clock::time_point> el_track_impl::last_accessed_at()
+std::optional<system_clock::time_point> el_track_impl::last_accessed_at()
 
 {
     // TODO (haslersn): Is there a difference between
@@ -571,7 +571,7 @@ boost::optional<system_clock::time_point> el_track_impl::last_accessed_at()
 }
 
 void el_track_impl::set_last_accessed_at(
-    boost::optional<system_clock::time_point> accessed_at)
+    std::optional<system_clock::time_point> accessed_at)
 {
     if (accessed_at)
     {
@@ -590,34 +590,34 @@ void el_track_impl::set_last_accessed_at(
     }
     else
     {
-        set_metadata_int(metadata_int_type::last_accessed_ts, boost::none);
+        set_metadata_int(metadata_int_type::last_accessed_ts, std::nullopt);
     }
 }
 
-boost::optional<system_clock::time_point> el_track_impl::last_modified_at()
+std::optional<system_clock::time_point> el_track_impl::last_modified_at()
 
 {
     return to_time_point(get_metadata_int(metadata_int_type::last_modified_ts));
 }
 
 void el_track_impl::set_last_modified_at(
-    boost::optional<system_clock::time_point> modified_at)
+    std::optional<system_clock::time_point> modified_at)
 {
     set_metadata_int(
         metadata_int_type::last_modified_ts, to_timestamp(modified_at));
 }
 
-boost::optional<system_clock::time_point> el_track_impl::last_played_at()
+std::optional<system_clock::time_point> el_track_impl::last_played_at()
 
 {
     return to_time_point(get_metadata_int(metadata_int_type::last_played_ts));
 }
 
 void el_track_impl::set_last_played_at(
-    boost::optional<system_clock::time_point> played_at)
+    std::optional<system_clock::time_point> played_at)
 {
-    static boost::optional<std::string> zero{"0"};
-    static boost::optional<std::string> one{"1"};
+    static std::optional<std::string> zero{"0"};
+    static std::optional<std::string> one{"1"};
     set_metadata_str(metadata_str_type::ever_played, played_at ? one : zero);
     set_metadata_int(
         metadata_int_type::last_played_ts, to_timestamp(played_at));
@@ -632,13 +632,13 @@ void el_track_impl::set_last_played_at(
     }
 }
 
-boost::optional<loop> el_track_impl::loop_at(int32_t index)
+std::optional<loop> el_track_impl::loop_at(int32_t index)
 {
     auto loops_d = get_loops_data();
     return std::move(loops_d.loops[index]);
 }
 
-void el_track_impl::set_loop_at(int32_t index, boost::optional<loop> l)
+void el_track_impl::set_loop_at(int32_t index, std::optional<loop> l)
 {
     el_transaction_guard_impl trans{storage_};
     auto loops_d = get_loops_data();
@@ -647,13 +647,13 @@ void el_track_impl::set_loop_at(int32_t index, boost::optional<loop> l)
     trans.commit();
 }
 
-std::array<boost::optional<loop>, 8> el_track_impl::loops()
+std::array<std::optional<loop>, 8> el_track_impl::loops()
 {
     auto loops_d = get_loops_data();
     return std::move(loops_d.loops);
 }
 
-void el_track_impl::set_loops(std::array<boost::optional<loop>, 8> cues)
+void el_track_impl::set_loops(std::array<std::optional<loop>, 8> cues)
 {
     el_transaction_guard_impl trans{storage_};
     loops_data loops_d;
@@ -668,12 +668,12 @@ std::vector<waveform_entry> el_track_impl::overview_waveform()
     return std::move(overview_waveform_d.waveform);
 }
 
-boost::optional<std::string> el_track_impl::publisher()
+std::optional<std::string> el_track_impl::publisher()
 {
     return get_metadata_str(metadata_str_type::publisher);
 }
 
-void el_track_impl::set_publisher(boost::optional<std::string> publisher)
+void el_track_impl::set_publisher(std::optional<std::string> publisher)
 {
     set_metadata_str(metadata_str_type::publisher, publisher);
 }
@@ -711,16 +711,16 @@ void el_track_impl::set_relative_path(std::string relative_path)
     set_metadata_str(metadata_str_type::file_extension, extension);
 }
 
-boost::optional<sampling_info> el_track_impl::sampling()
+std::optional<sampling_info> el_track_impl::sampling()
 {
     return get_track_data().sampling;
 }
 
-void el_track_impl::set_sampling(boost::optional<sampling_info> sampling)
+void el_track_impl::set_sampling(std::optional<sampling_info> sampling)
 {
     el_transaction_guard_impl trans{storage_};
 
-    boost::optional<int64_t> secs;
+    std::optional<int64_t> secs;
     if (sampling)
     {
         secs = static_cast<int64_t>(
@@ -738,7 +738,7 @@ void el_track_impl::set_sampling(boost::optional<sampling_info> sampling)
     }
     else
     {
-        set_metadata_str(metadata_str_type::duration_mm_ss, boost::none);
+        set_metadata_str(metadata_str_type::duration_mm_ss, std::nullopt);
     }
     set_cell("length", secs);
     set_cell("lengthCalculated", secs);
@@ -781,22 +781,22 @@ void el_track_impl::set_sampling(boost::optional<sampling_info> sampling)
     trans.commit();
 }
 
-boost::optional<std::string> el_track_impl::title()
+std::optional<std::string> el_track_impl::title()
 {
     return get_metadata_str(metadata_str_type::title);
 }
 
-void el_track_impl::set_title(boost::optional<std::string> title)
+void el_track_impl::set_title(std::optional<std::string> title)
 {
     set_metadata_str(metadata_str_type::title, title);
 }
 
-boost::optional<int32_t> el_track_impl::track_number()
+std::optional<int32_t> el_track_impl::track_number()
 {
-    return get_cell<boost::optional<int32_t>>("playOrder");
+    return get_cell<std::optional<int32_t>>("playOrder");
 }
 
-void el_track_impl::set_track_number(boost::optional<int32_t> track_number)
+void el_track_impl::set_track_number(std::optional<int32_t> track_number)
 {
     set_cell("playOrder", track_number);
 }
@@ -844,12 +844,12 @@ void el_track_impl::set_waveform(std::vector<waveform_entry> waveform)
     trans.commit();
 }
 
-boost::optional<int32_t> el_track_impl::year()
+std::optional<int32_t> el_track_impl::year()
 {
-    return get_cell<boost::optional<int32_t>>("year");
+    return get_cell<std::optional<int32_t>>("year");
 }
 
-void el_track_impl::set_year(boost::optional<int32_t> year)
+void el_track_impl::set_year(std::optional<int32_t> year)
 {
     set_cell("year", year);
 }

--- a/src/djinterop/enginelibrary/el_track_impl.hpp
+++ b/src/djinterop/enginelibrary/el_track_impl.hpp
@@ -19,11 +19,10 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include <djinterop/enginelibrary.hpp>
 #include <djinterop/enginelibrary/el_storage.hpp>
@@ -68,18 +67,18 @@ class el_track_impl : public djinterop::track_impl
 public:
     el_track_impl(std::shared_ptr<el_storage> storage, int64_t id);
 
-    boost::optional<std::string> get_metadata_str(metadata_str_type type);
+    std::optional<std::string> get_metadata_str(metadata_str_type type);
     void set_metadata_str(
-        metadata_str_type type, boost::optional<std::string> content);
+        metadata_str_type type, std::optional<std::string> content);
     void set_metadata_str(metadata_str_type type, const std::string& content);
-    boost::optional<int64_t> get_metadata_int(metadata_int_type type);
+    std::optional<int64_t> get_metadata_int(metadata_int_type type);
     void set_metadata_int(
-        metadata_int_type type, boost::optional<int64_t> content);
+        metadata_int_type type, std::optional<int64_t> content);
 
     template <typename T>
     T get_cell(const char* column_name)
     {
-        boost::optional<T> result;
+        std::optional<T> result;
         storage_->db << (std::string{"SELECT "} + column_name +
                          " FROM Track WHERE id = ?")
                      << id() >>
@@ -112,7 +111,7 @@ public:
     template <typename T>
     T get_perfdata(const char* column_name)
     {
-        boost::optional<T> result;
+        std::optional<T> result;
         storage_->db << (std::string{"SELECT "} + column_name +
                          " From PerformanceData WHERE id = ?")
                      << id() >>
@@ -217,79 +216,79 @@ public:
     void set_adjusted_beatgrid(std::vector<beatgrid_marker> beatgrid) override;
     double adjusted_main_cue() override;
     void set_adjusted_main_cue(double sample_offset) override;
-    boost::optional<std::string> album() override;
-    void set_album(boost::optional<std::string> album) override;
-    boost::optional<int64_t> album_art_id() override;
-    void set_album_art_id(boost::optional<int64_t> album_art_id) override;
-    boost::optional<std::string> artist() override;
-    void set_artist(boost::optional<std::string> artist) override;
-    boost::optional<double> average_loudness() override;
+    std::optional<std::string> album() override;
+    void set_album(std::optional<std::string> album) override;
+    std::optional<int64_t> album_art_id() override;
+    void set_album_art_id(std::optional<int64_t> album_art_id) override;
+    std::optional<std::string> artist() override;
+    void set_artist(std::optional<std::string> artist) override;
+    std::optional<double> average_loudness() override;
     void set_average_loudness(
-        boost::optional<double> average_loudness) override;
-    boost::optional<int64_t> bitrate() override;
-    void set_bitrate(boost::optional<int64_t> bitrate) override;
-    boost::optional<double> bpm() override;
-    void set_bpm(boost::optional<double> bpm) override;
-    boost::optional<std::string> comment() override;
-    void set_comment(boost::optional<std::string> comment) override;
-    boost::optional<std::string> composer() override;
-    void set_composer(boost::optional<std::string> composer) override;
+        std::optional<double> average_loudness) override;
+    std::optional<int64_t> bitrate() override;
+    void set_bitrate(std::optional<int64_t> bitrate) override;
+    std::optional<double> bpm() override;
+    void set_bpm(std::optional<double> bpm) override;
+    std::optional<std::string> comment() override;
+    void set_comment(std::optional<std::string> comment) override;
+    std::optional<std::string> composer() override;
+    void set_composer(std::optional<std::string> composer) override;
     std::vector<djinterop::crate> containing_crates() override;
     database db() override;
     std::vector<beatgrid_marker> default_beatgrid() override;
     void set_default_beatgrid(std::vector<beatgrid_marker> beatgrid) override;
     double default_main_cue() override;
     void set_default_main_cue(double sample_offset) override;
-    boost::optional<std::chrono::milliseconds> duration() override;
+    std::optional<std::chrono::milliseconds> duration() override;
     std::string file_extension() override;
     std::string filename() override;
-    boost::optional<std::string> genre() override;
-    void set_genre(boost::optional<std::string> genre) override;
-    boost::optional<hot_cue> hot_cue_at(int32_t index) override;
-    void set_hot_cue_at(int32_t index, boost::optional<hot_cue> cue) override;
-    std::array<boost::optional<hot_cue>, 8> hot_cues() override;
-    void set_hot_cues(std::array<boost::optional<hot_cue>, 8> cues) override;
-    boost::optional<track_import_info> import_info() override;
+    std::optional<std::string> genre() override;
+    void set_genre(std::optional<std::string> genre) override;
+    std::optional<hot_cue> hot_cue_at(int32_t index) override;
+    void set_hot_cue_at(int32_t index, std::optional<hot_cue> cue) override;
+    std::array<std::optional<hot_cue>, 8> hot_cues() override;
+    void set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) override;
+    std::optional<track_import_info> import_info() override;
     void set_import_info(
-        const boost::optional<track_import_info>& import_info) override;
+        const std::optional<track_import_info>& import_info) override;
     bool is_valid() override;
-    boost::optional<musical_key> key() override;
-    void set_key(boost::optional<musical_key> key) override;
-    boost::optional<std::chrono::system_clock::time_point> last_accessed_at()
+    std::optional<musical_key> key() override;
+    void set_key(std::optional<musical_key> key) override;
+    std::optional<std::chrono::system_clock::time_point> last_accessed_at()
         override;
     void set_last_accessed_at(
-        boost::optional<std::chrono::system_clock::time_point> accessed_at)
+        std::optional<std::chrono::system_clock::time_point> accessed_at)
         override;
-    boost::optional<std::chrono::system_clock::time_point> last_modified_at()
+    std::optional<std::chrono::system_clock::time_point> last_modified_at()
         override;
     void set_last_modified_at(
-        boost::optional<std::chrono::system_clock::time_point> modified_at)
+        std::optional<std::chrono::system_clock::time_point> modified_at)
         override;
-    boost::optional<std::chrono::system_clock::time_point> last_played_at()
+    std::optional<std::chrono::system_clock::time_point> last_played_at()
         override;
     void set_last_played_at(
-        boost::optional<std::chrono::system_clock::time_point> played_at)
+        std::optional<std::chrono::system_clock::time_point> played_at)
         override;
-    boost::optional<loop> loop_at(int32_t index) override;
-    void set_loop_at(int32_t index, boost::optional<loop> l) override;
-    std::array<boost::optional<loop>, 8> loops() override;
-    void set_loops(std::array<boost::optional<loop>, 8> cues) override;
+    std::optional<loop> loop_at(int32_t index) override;
+    void set_loop_at(int32_t index, std::optional<loop> l) override;
+    std::array<std::optional<loop>, 8> loops() override;
+    void set_loops(std::array<std::optional<loop>, 8> cues) override;
     std::vector<waveform_entry> overview_waveform() override;
-    boost::optional<std::string> publisher() override;
-    void set_publisher(boost::optional<std::string> publisher) override;
+    std::optional<std::string> publisher() override;
+    void set_publisher(std::optional<std::string> publisher) override;
     int64_t required_waveform_samples_per_entry() override;
     std::string relative_path() override;
     void set_relative_path(std::string relative_path) override;
-    boost::optional<sampling_info> sampling() override;
-    void set_sampling(boost::optional<sampling_info> sampling) override;
-    boost::optional<std::string> title() override;
-    void set_title(boost::optional<std::string> title) override;
-    boost::optional<int32_t> track_number() override;
-    void set_track_number(boost::optional<int32_t> track_number) override;
+    std::optional<sampling_info> sampling() override;
+    void set_sampling(std::optional<sampling_info> sampling) override;
+    std::optional<std::string> title() override;
+    void set_title(std::optional<std::string> title) override;
+    std::optional<int32_t> track_number() override;
+    void set_track_number(std::optional<int32_t> track_number) override;
     std::vector<waveform_entry> waveform() override;
     void set_waveform(std::vector<waveform_entry> waveform) override;
-    boost::optional<int32_t> year() override;
-    void set_year(boost::optional<int32_t> year) override;
+    std::optional<int32_t> year() override;
+    void set_year(std::optional<int32_t> year) override;
 
 private:
     std::shared_ptr<el_storage> storage_;

--- a/src/djinterop/enginelibrary/performance_data_format.cpp
+++ b/src/djinterop/enginelibrary/performance_data_format.cpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <iomanip>
 #include <numeric>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -34,23 +35,23 @@ namespace enginelibrary
 namespace
 {
 template <typename T, typename U>
-boost::optional<std::decay_t<T>> prohibit(const U& sentinel, T&& data)
+std::optional<std::decay_t<T>> prohibit(const U& sentinel, T&& data)
 {
     if (data == sentinel)
     {
-        return boost::none;
+        return std::nullopt;
     }
-    return boost::make_optional(std::forward<T>(data));
+    return std::make_optional(std::forward<T>(data));
 }
 
 template <typename T, typename U>
-boost::optional<T> opt_static_cast(const boost::optional<U>& u)
+std::optional<T> opt_static_cast(const std::optional<U>& u)
 {
     if (!u)
     {
-        return boost::none;
+        return std::nullopt;
     }
-    return boost::make_optional(static_cast<T>(*u));
+    return std::make_optional(static_cast<T>(*u));
 }
 
 char* encode_beatgrid(const std::vector<beatgrid_marker>& beatgrid, char* ptr)
@@ -184,7 +185,7 @@ beat_data beat_data::decode(const std::vector<char>& compressed_data)
     std::tie(sampling.sample_rate, ptr) = decode_double_be(ptr);
     std::tie(sampling.sample_count, ptr) = decode_double_be(ptr);
     result.sampling = sampling.sample_rate != 0
-        ? boost::make_optional(sampling) : boost::none;
+        ? std::make_optional(sampling) : std::nullopt;
 
     uint8_t is_beat_data_set;
     std::tie(is_beat_data_set, ptr) = decode_uint8(ptr);
@@ -332,7 +333,7 @@ std::vector<char> loops_data::encode() const
 {
     auto total_label_length = std::accumulate(
         loops.begin(), loops.end(), int64_t{0},
-        [](int64_t x, const boost::optional<loop>& loop) {
+        [](int64_t x, const std::optional<loop>& loop) {
             return x + (loop ? loop->label.length() : 0);
         });
 
@@ -564,7 +565,7 @@ std::vector<char> quick_cues_data::encode() const
 {
     auto total_label_length = std::accumulate(
         hot_cues.begin(), hot_cues.end(), int64_t{0},
-        [](int64_t x, const boost::optional<hot_cue>& hot_cue) {
+        [](int64_t x, const std::optional<hot_cue>& hot_cue) {
             return x + (hot_cue ? hot_cue->label.length() : 0);
         });
 
@@ -743,7 +744,7 @@ track_data track_data::decode(const std::vector<char>& compressed_track_data)
     std::tie(sampling.sample_rate, ptr) = decode_double_be(ptr);
     std::tie(sampling.sample_count, ptr) = decode_int64_be(ptr);
     result.sampling = sampling.sample_rate != 0
-        ? boost::make_optional(sampling) : boost::none;
+        ? std::make_optional(sampling) : std::nullopt;
 
     double raw_average_loudness;
     std::tie(raw_average_loudness, ptr) = decode_double_be(ptr);

--- a/src/djinterop/enginelibrary/performance_data_format.hpp
+++ b/src/djinterop/enginelibrary/performance_data_format.hpp
@@ -19,9 +19,8 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include <djinterop/performance_data.hpp>
 
@@ -33,7 +32,7 @@ namespace enginelibrary
 {
 struct beat_data
 {
-    boost::optional<sampling_info> sampling;
+    std::optional<sampling_info> sampling;
     std::vector<beatgrid_marker> default_beatgrid;
     std::vector<beatgrid_marker> adjusted_beatgrid;
 
@@ -73,7 +72,7 @@ struct high_res_waveform_data
 
 struct loops_data
 {
-    std::array<boost::optional<loop>, 8> loops;  // Don't use curly braces here!
+    std::array<std::optional<loop>, 8> loops;  // Don't use curly braces here!
 
     loops_data() noexcept = default;
 
@@ -110,7 +109,7 @@ struct overview_waveform_data
 
 struct quick_cues_data
 {
-    std::array<boost::optional<hot_cue>, 8> hot_cues;
+    std::array<std::optional<hot_cue>, 8> hot_cues;
     double adjusted_main_cue = 0;
     double default_main_cue = 0;
 
@@ -130,9 +129,9 @@ struct quick_cues_data
 
 struct track_data
 {
-    boost::optional<sampling_info> sampling;
-    boost::optional<double> average_loudness;  // range (0, 1]
-    boost::optional<musical_key> key;
+    std::optional<sampling_info> sampling;
+    std::optional<double> average_loudness;  // range (0, 1]
+    std::optional<musical_key> key;
 
     track_data() noexcept = default;
 

--- a/src/djinterop/impl/crate_impl.hpp
+++ b/src/djinterop/impl/crate_impl.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -46,12 +47,12 @@ public:
     virtual std::vector<crate> descendants() = 0;
     virtual bool is_valid() = 0;
     virtual std::string name() = 0;
-    virtual boost::optional<crate> parent() = 0;
+    virtual std::optional<crate> parent() = 0;
     virtual void remove_track(track tr) = 0;
-    virtual boost::optional<crate> sub_crate_by_name(
+    virtual std::optional<crate> sub_crate_by_name(
         const std::string& name) = 0;
     virtual void set_name(std::string name) = 0;
-    virtual void set_parent(boost::optional<crate> parent) = 0;
+    virtual void set_parent(std::optional<crate> parent) = 0;
     virtual std::vector<track> tracks() = 0;
 
 private:

--- a/src/djinterop/impl/database_impl.hpp
+++ b/src/djinterop/impl/database_impl.hpp
@@ -17,10 +17,9 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 namespace djinterop
 {
@@ -35,7 +34,7 @@ public:
     virtual ~database_impl();
 
     virtual transaction_guard begin_transaction() = 0;
-    virtual boost::optional<crate> crate_by_id(int64_t id) = 0;
+    virtual std::optional<crate> crate_by_id(int64_t id) = 0;
     virtual std::vector<crate> crates() = 0;
     virtual std::vector<crate> crates_by_name(const std::string& name) = 0;
     virtual crate create_root_crate(std::string name) = 0;
@@ -46,9 +45,9 @@ public:
     virtual void remove_crate(crate cr) = 0;
     virtual void remove_track(track tr) = 0;
     virtual std::vector<crate> root_crates() = 0;
-    virtual boost::optional<crate> root_crate_by_name(
+    virtual std::optional<crate> root_crate_by_name(
         const std::string& name) = 0;
-    virtual boost::optional<track> track_by_id(int64_t id) = 0;
+    virtual std::optional<track> track_by_id(int64_t id) = 0;
     virtual std::vector<track> tracks() = 0;
     virtual std::vector<track> tracks_by_relative_path(
         const std::string& relative_path) = 0;

--- a/src/djinterop/impl/track_impl.hpp
+++ b/src/djinterop/impl/track_impl.hpp
@@ -18,10 +18,9 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 #include <string>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include <djinterop/performance_data.hpp>
 
@@ -45,23 +44,23 @@ public:
         std::vector<beatgrid_marker> beatgrid) = 0;
     virtual double adjusted_main_cue() = 0;
     virtual void set_adjusted_main_cue(double sample_offset) = 0;
-    virtual boost::optional<std::string> album() = 0;
-    virtual void set_album(boost::optional<std::string> album) = 0;
-    virtual boost::optional<int64_t> album_art_id() = 0;
-    virtual void set_album_art_id(boost::optional<int64_t> album_art_id) = 0;
-    virtual boost::optional<std::string> artist() = 0;
-    virtual void set_artist(boost::optional<std::string> artist) = 0;
-    virtual boost::optional<double> average_loudness() = 0;
+    virtual std::optional<std::string> album() = 0;
+    virtual void set_album(std::optional<std::string> album) = 0;
+    virtual std::optional<int64_t> album_art_id() = 0;
+    virtual void set_album_art_id(std::optional<int64_t> album_art_id) = 0;
+    virtual std::optional<std::string> artist() = 0;
+    virtual void set_artist(std::optional<std::string> artist) = 0;
+    virtual std::optional<double> average_loudness() = 0;
     virtual void set_average_loudness(
-        boost::optional<double> average_loudness) = 0;
-    virtual boost::optional<int64_t> bitrate() = 0;
-    virtual void set_bitrate(boost::optional<int64_t> bitrate) = 0;
-    virtual boost::optional<double> bpm() = 0;
-    virtual void set_bpm(boost::optional<double> bpm) = 0;
-    virtual boost::optional<std::string> comment() = 0;
-    virtual void set_comment(boost::optional<std::string> comment) = 0;
-    virtual boost::optional<std::string> composer() = 0;
-    virtual void set_composer(boost::optional<std::string> composer) = 0;
+        std::optional<double> average_loudness) = 0;
+    virtual std::optional<int64_t> bitrate() = 0;
+    virtual void set_bitrate(std::optional<int64_t> bitrate) = 0;
+    virtual std::optional<double> bpm() = 0;
+    virtual void set_bpm(std::optional<double> bpm) = 0;
+    virtual std::optional<std::string> comment() = 0;
+    virtual void set_comment(std::optional<std::string> comment) = 0;
+    virtual std::optional<std::string> composer() = 0;
+    virtual void set_composer(std::optional<std::string> composer) = 0;
     virtual std::vector<crate> containing_crates() = 0;
     virtual database db() = 0;
     virtual std::vector<beatgrid_marker> default_beatgrid() = 0;
@@ -69,56 +68,56 @@ public:
         std::vector<beatgrid_marker> beatgrid) = 0;
     virtual double default_main_cue() = 0;
     virtual void set_default_main_cue(double sample_offset) = 0;
-    virtual boost::optional<std::chrono::milliseconds> duration() = 0;
+    virtual std::optional<std::chrono::milliseconds> duration() = 0;
     virtual std::string file_extension() = 0;
     virtual std::string filename() = 0;
-    virtual boost::optional<std::string> genre() = 0;
-    virtual void set_genre(boost::optional<std::string> genre) = 0;
-    virtual boost::optional<hot_cue> hot_cue_at(int32_t index) = 0;
+    virtual std::optional<std::string> genre() = 0;
+    virtual void set_genre(std::optional<std::string> genre) = 0;
+    virtual std::optional<hot_cue> hot_cue_at(int32_t index) = 0;
     virtual void set_hot_cue_at(
-        int32_t index, boost::optional<hot_cue> cue) = 0;
-    virtual std::array<boost::optional<hot_cue>, 8> hot_cues() = 0;
-    virtual void set_hot_cues(std::array<boost::optional<hot_cue>, 8> cues) = 0;
-    virtual boost::optional<track_import_info> import_info() = 0;
+        int32_t index, std::optional<hot_cue> cue) = 0;
+    virtual std::array<std::optional<hot_cue>, 8> hot_cues() = 0;
+    virtual void set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) = 0;
+    virtual std::optional<track_import_info> import_info() = 0;
     virtual void set_import_info(
-        const boost::optional<track_import_info>& import_info) = 0;
+        const std::optional<track_import_info>& import_info) = 0;
     virtual bool is_valid() = 0;
-    virtual boost::optional<musical_key> key() = 0;
-    virtual void set_key(boost::optional<musical_key> key) = 0;
-    virtual boost::optional<std::chrono::system_clock::time_point>
+    virtual std::optional<musical_key> key() = 0;
+    virtual void set_key(std::optional<musical_key> key) = 0;
+    virtual std::optional<std::chrono::system_clock::time_point>
     last_accessed_at() = 0;
     virtual void set_last_accessed_at(
-        boost::optional<std::chrono::system_clock::time_point>
+        std::optional<std::chrono::system_clock::time_point>
             last_accessed_at) = 0;
-    virtual boost::optional<std::chrono::system_clock::time_point>
+    virtual std::optional<std::chrono::system_clock::time_point>
     last_modified_at() = 0;
     virtual void set_last_modified_at(
-        boost::optional<std::chrono::system_clock::time_point>
+        std::optional<std::chrono::system_clock::time_point>
             last_modified_at) = 0;
-    virtual boost::optional<std::chrono::system_clock::time_point>
+    virtual std::optional<std::chrono::system_clock::time_point>
     last_played_at() = 0;
     virtual void set_last_played_at(
-        boost::optional<std::chrono::system_clock::time_point> time) = 0;
-    virtual boost::optional<loop> loop_at(int32_t index) = 0;
-    virtual void set_loop_at(int32_t index, boost::optional<loop> l) = 0;
-    virtual std::array<boost::optional<loop>, 8> loops() = 0;
-    virtual void set_loops(std::array<boost::optional<loop>, 8> loops) = 0;
+        std::optional<std::chrono::system_clock::time_point> time) = 0;
+    virtual std::optional<loop> loop_at(int32_t index) = 0;
+    virtual void set_loop_at(int32_t index, std::optional<loop> l) = 0;
+    virtual std::array<std::optional<loop>, 8> loops() = 0;
+    virtual void set_loops(std::array<std::optional<loop>, 8> loops) = 0;
     virtual std::vector<waveform_entry> overview_waveform() = 0;
-    virtual boost::optional<std::string> publisher() = 0;
-    virtual void set_publisher(boost::optional<std::string> publisher) = 0;
+    virtual std::optional<std::string> publisher() = 0;
+    virtual void set_publisher(std::optional<std::string> publisher) = 0;
     virtual int64_t required_waveform_samples_per_entry() = 0;
     virtual std::string relative_path() = 0;
     virtual void set_relative_path(std::string relative_path) = 0;
-    virtual boost::optional<sampling_info> sampling() = 0;
-    virtual void set_sampling(boost::optional<sampling_info> sample_rate) = 0;
-    virtual boost::optional<std::string> title() = 0;
-    virtual void set_title(boost::optional<std::string> title) = 0;
-    virtual boost::optional<int32_t> track_number() = 0;
-    virtual void set_track_number(boost::optional<int32_t> track_number) = 0;
+    virtual std::optional<sampling_info> sampling() = 0;
+    virtual void set_sampling(std::optional<sampling_info> sample_rate) = 0;
+    virtual std::optional<std::string> title() = 0;
+    virtual void set_title(std::optional<std::string> title) = 0;
+    virtual std::optional<int32_t> track_number() = 0;
+    virtual void set_track_number(std::optional<int32_t> track_number) = 0;
     virtual std::vector<waveform_entry> waveform() = 0;
     virtual void set_waveform(std::vector<waveform_entry> waveform) = 0;
-    virtual boost::optional<int32_t> year() = 0;
-    virtual void set_year(boost::optional<int32_t> year) = 0;
+    virtual std::optional<int32_t> year() = 0;
+    virtual void set_year(std::optional<int32_t> year) = 0;
 
 private:
     int64_t id_;

--- a/src/djinterop/impl/util.cpp
+++ b/src/djinterop/impl/util.cpp
@@ -26,10 +26,10 @@ std::string get_filename(const std::string& file_path)
     return file_path.substr(slash_pos + 1);
 }
 
-boost::optional<std::string> get_file_extension(const std::string& file_path)
+std::optional<std::string> get_file_extension(const std::string& file_path)
 {
     auto filename = get_filename(file_path);
-    boost::optional<std::string> file_extension;
+    std::optional<std::string> file_extension;
     auto dot_pos = filename.rfind('.');
     if (dot_pos != std::string::npos)
     {

--- a/src/djinterop/impl/util.hpp
+++ b/src/djinterop/impl/util.hpp
@@ -18,23 +18,10 @@
 #pragma once
 
 #include <optional>
-#include <boost/optional.hpp>
 
 namespace djinterop
 {
 std::string get_filename(const std::string& file_path);
-boost::optional<std::string> get_file_extension(const std::string& file_path);
-
-template <typename T>
-std::optional<T> from_boost_optional(boost::optional<T> opt)
-{
-    return opt ? std::optional<T>{*opt} : std::nullopt;
-}
-
-template <typename T>
-boost::optional<T> to_boost_optional(std::optional<T> opt)
-{
-    return opt ? boost::optional<T>{*opt} : boost::none;
-}
+std::optional<std::string> get_file_extension(const std::string& file_path);
 
 }  // namespace djinterop

--- a/src/djinterop/track.cpp
+++ b/src/djinterop/track.cpp
@@ -17,19 +17,13 @@
 
 #include <algorithm>
 #include <chrono>
-#include <iomanip>
-#include <random>
-#include <sstream>
 #include <string>
 #include <vector>
-
-#include <sqlite_modern_cpp.h>
 
 #include <djinterop/crate.hpp>
 #include <djinterop/database.hpp>
 #include <djinterop/impl/database_impl.hpp>
 #include <djinterop/impl/track_impl.hpp>
-#include <djinterop/impl/util.hpp>
 #include <djinterop/track.hpp>
 
 using std::chrono::duration_cast;
@@ -67,12 +61,12 @@ void track::set_adjusted_main_cue(double sample_offset) const
 
 std::optional<std::string> track::album() const
 {
-    return from_boost_optional(pimpl_->album());
+    return pimpl_->album();
 }
 
 void track::set_album(std::optional<std::string> album) const
 {
-    pimpl_->set_album(to_boost_optional(album));
+    pimpl_->set_album(album);
 }
 
 void track::set_album(std::string album) const
@@ -82,12 +76,12 @@ void track::set_album(std::string album) const
 
 std::optional<int64_t> track::album_art_id() const
 {
-    return from_boost_optional(pimpl_->album_art_id());
+    return pimpl_->album_art_id();
 }
 
 void track::set_album_art_id(std::optional<int64_t> album_art_id) const
 {
-    pimpl_->set_album_art_id(to_boost_optional(album_art_id));
+    pimpl_->set_album_art_id(album_art_id);
 }
 
 void track::set_album_art_id(int64_t album_art_id) const
@@ -97,12 +91,12 @@ void track::set_album_art_id(int64_t album_art_id) const
 
 std::optional<std::string> track::artist() const
 {
-    return from_boost_optional(pimpl_->artist());
+    return pimpl_->artist();
 }
 
 void track::set_artist(std::optional<std::string> artist) const
 {
-    pimpl_->set_artist(to_boost_optional(artist));
+    pimpl_->set_artist(artist);
 }
 
 void track::set_artist(std::string artist) const
@@ -112,12 +106,12 @@ void track::set_artist(std::string artist) const
 
 std::optional<double> track::average_loudness() const
 {
-    return from_boost_optional(pimpl_->average_loudness());
+    return pimpl_->average_loudness();
 }
 
 void track::set_average_loudness(std::optional<double> average_loudness) const
 {
-    pimpl_->set_average_loudness(to_boost_optional(average_loudness));
+    pimpl_->set_average_loudness(average_loudness);
 }
 
 void track::set_average_loudness(double average_loudness) const
@@ -127,12 +121,12 @@ void track::set_average_loudness(double average_loudness) const
 
 std::optional<int64_t> track::bitrate() const
 {
-    return from_boost_optional(pimpl_->bitrate());
+    return pimpl_->bitrate();
 }
 
 void track::set_bitrate(std::optional<int64_t> bitrate) const
 {
-    pimpl_->set_bitrate(to_boost_optional(bitrate));
+    pimpl_->set_bitrate(bitrate);
 }
 
 void track::set_bitrate(int64_t bitrate) const
@@ -142,12 +136,12 @@ void track::set_bitrate(int64_t bitrate) const
 
 std::optional<double> track::bpm() const
 {
-    return from_boost_optional(pimpl_->bpm());
+    return pimpl_->bpm();
 }
 
 void track::set_bpm(std::optional<double> bpm) const
 {
-    pimpl_->set_bpm(to_boost_optional(bpm));
+    pimpl_->set_bpm(bpm);
 }
 
 void track::set_bpm(double bpm) const
@@ -157,12 +151,12 @@ void track::set_bpm(double bpm) const
 
 std::optional<std::string> track::comment() const
 {
-    return from_boost_optional(pimpl_->comment());
+    return pimpl_->comment();
 }
 
 void track::set_comment(std::optional<std::string> comment) const
 {
-    pimpl_->set_comment(to_boost_optional(comment));
+    pimpl_->set_comment(comment);
 }
 
 void track::set_comment(std::string comment) const
@@ -172,12 +166,12 @@ void track::set_comment(std::string comment) const
 
 std::optional<std::string> track::composer() const
 {
-    return from_boost_optional(pimpl_->composer());
+    return pimpl_->composer();
 }
 
 void track::set_composer(std::optional<std::string> composer) const
 {
-    pimpl_->set_composer(to_boost_optional(composer));
+    pimpl_->set_composer(composer);
 }
 
 void track::set_composer(std::string composer) const
@@ -217,7 +211,7 @@ void track::set_default_main_cue(double sample_offset) const
 
 std::optional<milliseconds> track::duration() const
 {
-    return from_boost_optional(pimpl_->duration());
+    return pimpl_->duration();
 }
 
 std::string track::file_extension() const
@@ -232,12 +226,12 @@ std::string track::filename() const
 
 std::optional<std::string> track::genre() const
 {
-    return from_boost_optional(pimpl_->genre());
+    return pimpl_->genre();
 }
 
 void track::set_genre(std::optional<std::string> genre) const
 {
-    pimpl_->set_genre(to_boost_optional(genre));
+    pimpl_->set_genre(genre);
 }
 
 void track::set_genre(std::string genre) const
@@ -247,12 +241,12 @@ void track::set_genre(std::string genre) const
 
 std::optional<hot_cue> track::hot_cue_at(int32_t index) const
 {
-    return from_boost_optional(pimpl_->hot_cue_at(index));
+    return pimpl_->hot_cue_at(index);
 }
 
 void track::set_hot_cue_at(int32_t index, std::optional<hot_cue> cue) const
 {
-    pimpl_->set_hot_cue_at(index, to_boost_optional(cue));
+    pimpl_->set_hot_cue_at(index, cue);
 }
 
 void track::set_hot_cue_at(int32_t index, hot_cue cue) const
@@ -262,29 +256,12 @@ void track::set_hot_cue_at(int32_t index, hot_cue cue) const
 
 std::array<std::optional<hot_cue>, 8> track::hot_cues() const
 {
-    std::array<std::optional<hot_cue>, 8> results;
-    auto bcues = pimpl_->hot_cues();
-    std::transform(
-            bcues.begin(), bcues.end(), results.begin(),
-            [](boost::optional<hot_cue> bcue) ->
-                    std::optional<hot_cue>
-            {
-                return from_boost_optional(bcue);
-            });
-    return results;
+    return pimpl_->hot_cues();
 }
 
 void track::set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) const
 {
-    std::array<boost::optional<hot_cue>, 8> bcues;
-    std::transform(
-            cues.begin(), cues.end(), bcues.begin(),
-            [](std::optional<hot_cue> cue) ->
-                    boost::optional<hot_cue>
-                {
-                    return to_boost_optional(cue);
-                });
-    pimpl_->set_hot_cues(std::move(bcues));
+    pimpl_->set_hot_cues(std::move(cues));
 }
 
 int64_t track::id() const
@@ -294,13 +271,13 @@ int64_t track::id() const
 
 std::optional<track_import_info> track::import_info() const
 {
-    return from_boost_optional(pimpl_->import_info());
+    return pimpl_->import_info();
 }
 
 void track::set_import_info(
     const std::optional<track_import_info>& import_info) const
 {
-    pimpl_->set_import_info(to_boost_optional(import_info));
+    pimpl_->set_import_info(import_info);
 }
 
 void track::set_import_info(const track_import_info& import_info) const
@@ -315,12 +292,12 @@ bool track::is_valid() const
 
 std::optional<musical_key> track::key() const
 {
-    return from_boost_optional(pimpl_->key());
+    return pimpl_->key();
 }
 
 void track::set_key(std::optional<musical_key> key) const
 {
-    pimpl_->set_key(to_boost_optional(key));
+    pimpl_->set_key(key);
 }
 
 void track::set_key(musical_key key) const
@@ -330,13 +307,13 @@ void track::set_key(musical_key key) const
 
 std::optional<system_clock::time_point> track::last_accessed_at() const
 {
-    return from_boost_optional(pimpl_->last_accessed_at());
+    return pimpl_->last_accessed_at();
 }
 
 void track::set_last_accessed_at(
     std::optional<system_clock::time_point> accessed_at) const
 {
-    pimpl_->set_last_accessed_at(to_boost_optional(accessed_at));
+    pimpl_->set_last_accessed_at(accessed_at);
 }
 
 void track::set_last_accessed_at(system_clock::time_point accessed_at) const
@@ -346,13 +323,13 @@ void track::set_last_accessed_at(system_clock::time_point accessed_at) const
 
 std::optional<system_clock::time_point> track::last_modified_at() const
 {
-    return from_boost_optional(pimpl_->last_modified_at());
+    return pimpl_->last_modified_at();
 }
 
 void track::set_last_modified_at(
     std::optional<system_clock::time_point> modified_at) const
 {
-    pimpl_->set_last_modified_at(to_boost_optional(modified_at));
+    pimpl_->set_last_modified_at(modified_at);
 }
 
 void track::set_last_modified_at(system_clock::time_point modified_at) const
@@ -362,13 +339,13 @@ void track::set_last_modified_at(system_clock::time_point modified_at) const
 
 std::optional<system_clock::time_point> track::last_played_at() const
 {
-    return from_boost_optional(pimpl_->last_played_at());
+    return pimpl_->last_played_at();
 }
 
 void track::set_last_played_at(
     std::optional<system_clock::time_point> played_at) const
 {
-    pimpl_->set_last_played_at(to_boost_optional(played_at));
+    pimpl_->set_last_played_at(played_at);
 }
 
 void track::set_last_played_at(system_clock::time_point played_at) const
@@ -378,12 +355,12 @@ void track::set_last_played_at(system_clock::time_point played_at) const
 
 std::optional<loop> track::loop_at(int32_t index) const
 {
-    return from_boost_optional(pimpl_->loop_at(index));
+    return pimpl_->loop_at(index);
 }
 
 void track::set_loop_at(int32_t index, std::optional<loop> l) const
 {
-    pimpl_->set_loop_at(index, to_boost_optional(l));
+    pimpl_->set_loop_at(index, l);
 }
 
 void track::set_loop_at(int32_t index, loop l) const
@@ -393,27 +370,12 @@ void track::set_loop_at(int32_t index, loop l) const
 
 std::array<std::optional<loop>, 8> track::loops() const
 {
-    std::array<std::optional<loop>, 8> results;
-    auto bloops = pimpl_->loops();
-    std::transform(
-            bloops.begin(), bloops.end(), results.begin(),
-            [](boost::optional<loop> l) -> std::optional<loop>
-            {
-                return from_boost_optional(l);
-            });
-    return results;
+    return pimpl_->loops();
 }
 
 void track::set_loops(std::array<std::optional<loop>, 8> loops) const
 {
-    std::array<boost::optional<loop>, 8> bloops;
-    std::transform(
-            loops.begin(), loops.end(), bloops.begin(),
-            [](std::optional<loop> l) -> boost::optional<loop>
-            {
-                return to_boost_optional(l);
-            });
-    pimpl_->set_loops(std::move(bloops));
+    pimpl_->set_loops(std::move(loops));
 }
 
 std::vector<waveform_entry> track::overview_waveform() const
@@ -423,12 +385,12 @@ std::vector<waveform_entry> track::overview_waveform() const
 
 std::optional<std::string> track::publisher() const
 {
-    return from_boost_optional(pimpl_->publisher());
+    return pimpl_->publisher();
 }
 
 void track::set_publisher(std::optional<std::string> publisher) const
 {
-    pimpl_->set_publisher(to_boost_optional(publisher));
+    pimpl_->set_publisher(publisher);
 }
 
 void track::set_publisher(std::string publisher) const
@@ -453,12 +415,12 @@ void track::set_relative_path(std::string relative_path) const
 
 std::optional<sampling_info> track::sampling() const
 {
-    return from_boost_optional(pimpl_->sampling());
+    return pimpl_->sampling();
 }
 
 void track::set_sampling(std::optional<sampling_info> sampling) const
 {
-    pimpl_->set_sampling(to_boost_optional(sampling));
+    pimpl_->set_sampling(sampling);
 }
 
 void track::set_sampling(sampling_info sampling) const
@@ -468,12 +430,12 @@ void track::set_sampling(sampling_info sampling) const
 
 std::optional<std::string> track::title() const
 {
-    return from_boost_optional(pimpl_->title());
+    return pimpl_->title();
 }
 
 void track::set_title(std::optional<std::string> title) const
 {
-    pimpl_->set_title(to_boost_optional(title));
+    pimpl_->set_title(title);
 }
 
 void track::set_title(std::string title) const
@@ -483,12 +445,12 @@ void track::set_title(std::string title) const
 
 std::optional<int32_t> track::track_number() const
 {
-    return from_boost_optional(pimpl_->track_number());
+    return pimpl_->track_number();
 }
 
 void track::set_track_number(std::optional<int32_t> track_number) const
 {
-    pimpl_->set_track_number(to_boost_optional(track_number));
+    pimpl_->set_track_number(track_number);
 }
 
 void track::set_track_number(int32_t track_number) const
@@ -508,12 +470,12 @@ void track::set_waveform(std::vector<waveform_entry> waveform) const
 
 std::optional<int32_t> track::year() const
 {
-    return from_boost_optional(pimpl_->year());
+    return pimpl_->year();
 }
 
 void track::set_year(std::optional<int32_t> year) const
 {
-    pimpl_->set_year(to_boost_optional(year));
+    pimpl_->set_year(year);
 }
 
 void track::set_year(int32_t year) const


### PR DESCRIPTION
Remove internal use of `boost::optional<T>` and use `std::optional<T>` instead.  Resolves issue #9 .

* Change to `std::optional<T>` throughout.
* Remove conversions.
* Remove feature compile definition for SQLite Modern CPP.
