### PR TITLE
Remove Boost UUID from library

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ How Do I Build It?
 
 * [SQLite3](https://sqlite.org)
 * [zlib](http://zlib.net)
-* [Boost](https://boost.org) (libraries required for unit tests; headers only for the main library)
+* [Boost](https://boost.org) (only required for unit tests, not the main library)
 
 `libdjinterop` uses the [Meson build system](https://mesonbuild.com).  Assuming you have the above dependencies in place, and the build tools, you can issue the following commands:
 
@@ -146,9 +146,9 @@ Thanks To
 `libdjinterop` makes use of a number of software libraries, and is extremely grateful for:
 
 * [Boost](https://boost.org)
+* [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)
 * [SQLite](https://sqlite.org)
 * [SQLite Modern C++ Wrapper](https://github.com/SqliteModernCpp/sqlite_modern_cpp)
 * [zlib](http://zlib.net)
-* [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html)
 
 Interfacing with the Engine Library database format was made a lot easier with the help of MixMasterG from ATGR, who is the author of the [Denon Conversion Utility](https://sellfy.com/atgr_production_team).

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,6 @@ dl_dep = cpp_compiler.find_library('dl', required: false)
 thread_dep = dependency('threads')
 sqlite3_dep = dependency('sqlite3', version: '>=3.11.0', fallback: ['sqlite', 'sqlite_dep'])
 zlib_dep = dependency('zlib', version: '>=1.2.8', fallback: ['zlib', 'zlib_dep'])
-boost_dep = dependency('boost', version: '>=1.65') # Header-only libraries
 
 inc = include_directories('include')
 

--- a/src/djinterop/enginelibrary/schema.cpp
+++ b/src/djinterop/enginelibrary/schema.cpp
@@ -18,9 +18,6 @@
 #include <string>
 
 #include <sqlite_modern_cpp.h>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 #include <djinterop/djinterop.hpp>
 #include <djinterop/enginelibrary/schema.hpp>

--- a/src/djinterop/enginelibrary/schema_1_6_0.cpp
+++ b/src/djinterop/enginelibrary/schema_1_6_0.cpp
@@ -15,20 +15,14 @@
     along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <string>
-
 #include <sqlite_modern_cpp.h>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 #include <djinterop/djinterop.hpp>
 #include <djinterop/enginelibrary/schema_1_6_0.hpp>
 #include <djinterop/enginelibrary/schema_validate_utils.hpp>
+#include <djinterop/impl/util.hpp>
 
-namespace djinterop
-{
-namespace enginelibrary
+namespace djinterop::enginelibrary
 {
 static void verify_album_art(sqlite::database &db)
 {
@@ -965,11 +959,11 @@ void create_music_schema_1_6_0(sqlite::database &db)
     db << "CREATE INDEX music.index_CopiedTrack_trackId ON CopiedTrack ( "
           "trackId )";
 
-    // Generate UUIDs for the Information table
-    boost::uuids::uuid uuid{boost::uuids::random_generator()()};
-    auto uuid_str = boost::uuids::to_string(uuid);
+    // Generate UUID for the Information table
+    auto uuid_str = generate_random_uuid();
 
-    // Not yet sure how the currentPlayedIndiciator value is formed.
+    // Not yet sure how the "currentPlayedIndiciator" (typo deliberate) value
+    // is formed.
     auto current_played_indicator_fake_value = 5100658837829259927l;
 
     // Insert row into Information
@@ -1009,9 +1003,8 @@ void create_performance_schema_1_6_0(sqlite::database &db)
     db << "CREATE INDEX perfdata.index_PerformanceData_id ON PerformanceData ( "
           "id )";
 
-    // Generate UUIDs for the Information table
-    boost::uuids::uuid uuid{boost::uuids::random_generator()()};
-    auto uuid_str = boost::uuids::to_string(uuid);
+    // Generate UUID for the Information table
+    auto uuid_str = generate_random_uuid();
 
     // Insert row into Information
     db << "INSERT INTO perfdata.Information ([uuid], [schemaVersionMajor], "
@@ -1021,5 +1014,4 @@ void create_performance_schema_1_6_0(sqlite::database &db)
        << version_1_6_0.pat << 0;
 }
 
-}  // namespace enginelibrary
-}  // namespace djinterop
+}  // namespace djinterop::enginelibrary

--- a/src/djinterop/enginelibrary/schema_1_7_1.cpp
+++ b/src/djinterop/enginelibrary/schema_1_7_1.cpp
@@ -15,20 +15,14 @@
     along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <string>
-
 #include <sqlite_modern_cpp.h>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 
 #include <djinterop/djinterop.hpp>
 #include <djinterop/enginelibrary/schema_1_7_1.hpp>
 #include <djinterop/enginelibrary/schema_validate_utils.hpp>
+#include <djinterop/impl/util.hpp>
 
-namespace djinterop
-{
-namespace enginelibrary
+namespace djinterop::enginelibrary
 {
 static void verify_album_art(sqlite::database &db)
 {
@@ -977,11 +971,11 @@ void create_music_schema_1_7_1(sqlite::database &db)
     db << "CREATE INDEX music.index_CopiedTrack_trackId ON CopiedTrack ( "
           "trackId )";
 
-    // Generate UUIDs for the Information table
-    boost::uuids::uuid uuid{boost::uuids::random_generator()()};
-    auto uuid_str = boost::uuids::to_string(uuid);
+    // Generate UUID for the Information table.
+    auto uuid_str = generate_random_uuid();
 
-    // Not yet sure how the currentPlayedIndiciator value is formed.
+    // Not yet sure how the "currentPlayedIndiciator" (typo deliberate) value
+    // is formed.
     auto current_played_indicator_fake_value = 5100658837829259927l;
 
     // Insert row into Information
@@ -1024,9 +1018,8 @@ void create_performance_schema_1_7_1(sqlite::database &db)
     db << "CREATE INDEX perfdata.index_PerformanceData_id ON PerformanceData ( "
           "id )";
 
-    // Generate UUIDs for the Information table
-    boost::uuids::uuid uuid{boost::uuids::random_generator()()};
-    auto uuid_str = boost::uuids::to_string(uuid);
+    // Generate UUID for the Information table
+    auto uuid_str = generate_random_uuid();
 
     // Insert row into Information
     db << "INSERT INTO perfdata.Information ([uuid], [schemaVersionMajor], "
@@ -1037,5 +1030,4 @@ void create_performance_schema_1_7_1(sqlite::database &db)
        << version_1_7_1.pat << 0 << 0;
 }
 
-}  // namespace enginelibrary
-}  // namespace djinterop
+}  // namespace djinterop::enginelibrary

--- a/src/djinterop/impl/util.cpp
+++ b/src/djinterop/impl/util.cpp
@@ -17,8 +17,15 @@
 
 #include <djinterop/impl/util.hpp>
 
+#include <ios>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+
 namespace djinterop
 {
+
 std::string get_filename(const std::string& file_path)
 {
     // TODO (haslersn): How to handle Windows path separator?
@@ -36,6 +43,55 @@ std::optional<std::string> get_file_extension(const std::string& file_path)
         file_extension = filename.substr(dot_pos + 1);
     }
     return file_extension;
+}
+
+std::string generate_random_uuid()
+{
+    static std::random_device rng;
+    static std::mt19937 generator{rng()};
+    static std::uniform_int_distribution<int> nibble_dist{0, 15};
+    static std::uniform_int_distribution<int> variant_nibble_dist{8, 11};
+
+    // Generate a version 4 (random), variant 1 UUID.
+    std::stringstream ss;
+    ss
+        << std::hex
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << "-"
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << "-4" // Version 4 indicator
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << "-"
+        << variant_nibble_dist(generator) // Variant 1 indicator
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << "-"
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator)
+        << nibble_dist(generator);
+    return ss.str();
 }
 
 }  // namespace djinterop

--- a/src/djinterop/impl/util.hpp
+++ b/src/djinterop/impl/util.hpp
@@ -18,10 +18,12 @@
 #pragma once
 
 #include <optional>
+#include <string>
 
 namespace djinterop
 {
 std::string get_filename(const std::string& file_path);
 std::optional<std::string> get_file_extension(const std::string& file_path);
+std::string generate_random_uuid();
 
 }  // namespace djinterop

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,13 +22,7 @@ sources = [
 ]
 
 # Dependencies required by the main library.
-core_deps = [thread_dep, dl_dep, sqlite3_dep, zlib_dep, boost_dep]
-
-if cpp_compiler.get_id() == 'msvc'
-    # Boost UUID on Windows uses bcrypt for random UUID generation.
-    bcrypt_dep = cpp_compiler.find_library('bcrypt')
-    core_deps += [bcrypt_dep]
-endif
+core_deps = [thread_dep, dl_dep, sqlite3_dep, zlib_dep]
 
 # Used by unit tests to reference internal classes.
 internal_inc = include_directories('.')


### PR DESCRIPTION
This PR removes any use of Boost UUID and replaces it with a simple generation utility method that uses functions from `<random>` in the Standard Library instead.

This also means that the main library has no Boost dependencies at all any longer.

Note that the unit tests still depend on Boost Filesystem for now.

Resolves #11 .