### PR TITLE
Enh/std optional support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The meson/ninja build should be preferred in all other cases.
 #
 cmake_minimum_required(VERSION 3.10)
-project(libdjinterop VERSION 0.11.0)
+project(libdjinterop VERSION 0.12.0)
 
 # Require C++17
 set(CMAKE_CXX_STANDARD 17)
@@ -17,6 +17,14 @@ find_package(SQLite3 3.11.0 REQUIRED)
 
 # Require zlib >= 1.2.8
 find_package(ZLIB 1.2.8 REQUIRED)
+
+# Generate config.hpp based on build-time environment.
+include(CheckIncludeFileCXX)
+CHECK_INCLUDE_FILE_CXX(optional DJINTEROP_STD_OPTIONAL)
+CHECK_INCLUDE_FILE_CXX(experimental/optional DJINTEROP_STD_EXPERIMENTAL_OPTIONAL)
+configure_file(
+    include/djinterop/config.hpp.in
+    include/djinterop/config.hpp)
 
 add_library(
     djinterop
@@ -50,6 +58,7 @@ target_include_directories(
     ${SQLite3_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}
     ext/sqlite_modern_cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/include
     include src)
 
 target_link_libraries(
@@ -60,7 +69,7 @@ target_link_libraries(
 install(TARGETS djinterop DESTINATION lib)
 install(FILES
     include/djinterop/album_art.hpp
-    include/djinterop/config.hpp
+    ${CMAKE_CURRENT_BINARY_DIR}/include/djinterop/config.hpp
     include/djinterop/crate.hpp
     include/djinterop/database.hpp
     include/djinterop/djinterop.hpp

--- a/example/engine_prime.cpp
+++ b/example/engine_prime.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     tr.set_year(1970);
     tr.set_title("Some Song"s);
     tr.set_artist("Some Artist"s);
-    tr.set_publisher(std::nullopt);  // std::nullopt indicates missing metadata
+    tr.set_publisher(djinterop::stdx::nullopt);  // indicates missing metadata
     tr.set_key(djinterop::musical_key::a_minor);
     tr.set_bitrate(320);
     tr.set_average_loudness(0.5);  // loudness range (0, 1]
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
     tr.set_adjusted_main_cue(2732);  // manually adjusted
 
     // There are always 8 hot cues, whereby each can optionally be set
-    std::array<std::optional<djinterop::hot_cue>, 8> cues;
+    std::array<djinterop::stdx::optional<djinterop::hot_cue>, 8> cues;
     cues[0] = djinterop::hot_cue{
         "Cue 1", 1377924.5,  // position in number of samples
         el::standard_pad_colors::pad_1};

--- a/include/djinterop/config.hpp.in
+++ b/include/djinterop/config.hpp.in
@@ -46,4 +46,10 @@
 #endif  // DJINTEROP_SOURCE
 #define DJINTEROP_LOCAL DJINTEROP_SYMBOL_LOCAL
 
+// Symbols defined after this point represent the environment at the time
+// that this library was built.  The environment when this library is used must
+// be compatible in order to use the library successfully.
+#cmakedefine DJINTEROP_STD_OPTIONAL
+#cmakedefine DJINTEROP_STD_EXPERIMENTAL_OPTIONAL
+
 #endif  // DJINTEROP_CONFIG_HPP

--- a/include/djinterop/crate.hpp
+++ b/include/djinterop/crate.hpp
@@ -23,11 +23,11 @@ Lesser General Public License for more details.
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
 #include <djinterop/config.hpp>
+#include <djinterop/optional.hpp>
 
 namespace djinterop
 {
@@ -111,7 +111,7 @@ public:
     ///
     /// If the crate doesn't have a parent, then `djinterop::nullopt` is
     /// returned.
-    std::optional<crate> parent() const;
+    stdx::optional<crate> parent() const;
 
     /// Removes a track from the crate
     ///
@@ -126,12 +126,12 @@ public:
     ///
     /// If `djinterop::nullopt` is given, then this crate will have no parent.
     /// That is, it becomes a root crate.
-    void set_parent(std::optional<crate> parent) const;
+    void set_parent(stdx::optional<crate> parent) const;
 
     /// Gets the sub-crate of this one with a given name.
     ///
     /// If no such crate is found, then `djinterop::nullopt` is returned.
-    std::optional<crate> sub_crate_by_name(const std::string& name) const;
+    stdx::optional<crate> sub_crate_by_name(const std::string& name) const;
 
     /// Returns the crate's contained tracks
     std::vector<track> tracks() const;

--- a/include/djinterop/database.hpp
+++ b/include/djinterop/database.hpp
@@ -25,17 +25,12 @@
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <djinterop/config.hpp>
-
-namespace sqlite
-{
-class database;
-}
+#include <djinterop/optional.hpp>
 
 namespace djinterop
 {
@@ -70,9 +65,9 @@ public:
 
     /// Returns the crate with the given ID
     ///
-    /// If no such crate exists in the database, then `djinterop::std::nullopt`
+    /// If no such crate exists in the database, then `djinterop::stdx::nullopt`
     /// is returned.
-    std::optional<crate> crate_by_id(int64_t id) const;
+    stdx::optional<crate> crate_by_id(int64_t id) const;
 
     /// Returns all crates contained in the database
     std::vector<crate> crates() const;
@@ -125,8 +120,8 @@ public:
 
     /// Returns the root-level crate with the given name.
     ///
-    /// If no such crate exists, then `djinterop::std::nullopt` is returned.
-    std::optional<crate> root_crate_by_name(const std::string& name) const;
+    /// If no such crate exists, then `djinterop::stdx::nullopt` is returned.
+    stdx::optional<crate> root_crate_by_name(const std::string& name) const;
 
     /// Returns all root crates contained in the database
     ///
@@ -135,9 +130,9 @@ public:
 
     /// Returns the track with the given id
     ///
-    /// If no such track exists in the database, then `djinterop::std::nullopt`
+    /// If no such track exists in the database, then `djinterop::stdx::nullopt`
     /// is returned.
-    std::optional<track> track_by_id(int64_t id) const;
+    stdx::optional<track> track_by_id(int64_t id) const;
 
     /// Returns all tracks whose `relative_path` attribute in the database
     /// matches the given string

--- a/include/djinterop/meson.build
+++ b/include/djinterop/meson.build
@@ -1,0 +1,20 @@
+# Generate config file based on build-time feature detection.
+# Note that most build configuration for public headers is handled in the
+# parent build file; this file exists solely because the `output` parameter
+# of configure_file() does not, at the time of writing (meson 0.55.0), support
+# writing the output file to a different directory.
+conf_data = configuration_data()
+if cpp_compiler.has_header('optional')
+    conf_data.set10('DJINTEROP_STD_OPTIONAL', true)
+endif
+if cpp_compiler.has_header('experimental/optional')
+    conf_data.set10('DJINTEROP_STD_EXPERIMENTAL_OPTIONAL', true)
+endif
+configure_file(
+    input: 'config.hpp.in',
+    output: 'config.hpp',
+    configuration: conf_data,
+    format: 'cmake',
+    install_dir: get_option('includedir') + '/djinterop'
+)
+

--- a/include/djinterop/optional.hpp
+++ b/include/djinterop/optional.hpp
@@ -1,0 +1,63 @@
+/*
+    This file is part of libdjinterop.
+
+    libdjinterop is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libdjinterop is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef DJINTEROP_OPTIONAL_HPP
+#define DJINTEROP_OPTIONAL_HPP
+
+#include <djinterop/config.hpp>
+
+#ifdef DJINTEROP_STD_OPTIONAL
+
+#include <optional>
+
+namespace djinterop
+{
+namespace stdx
+{
+using std::bad_optional_access;
+using std::in_place;
+using std::in_place_t;
+using std::make_optional;
+using std::nullopt;
+using std::nullopt_t;
+using std::optional;
+}  // namespace stdx
+}  // namespace djinterop
+
+#elif DJINTEROP_STD_EXPERIMENTAL_OPTIONAL
+#include <experimental/optional>
+
+namespace djinterop
+{
+namespace stdx
+{
+using std::experimental::bad_optional_access;
+using std::experimental::in_place;
+using std::experimental::in_place_t;
+using std::experimental::make_optional;
+using std::experimental::nullopt;
+using std::experimental::nullopt_t;
+using std::experimental::optional;
+}  // namespace stdx
+}  // namespace djinterop
+
+#else
+#error This library requires support for optional<T>, but none was found
+#endif
+
+#endif  // DJINTEROP_OPTIONAL_HPP

--- a/include/djinterop/track.hpp
+++ b/include/djinterop/track.hpp
@@ -27,13 +27,13 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <djinterop/config.hpp>
 #include <djinterop/musical_key.hpp>
+#include <djinterop/optional.hpp>
 #include <djinterop/performance_data.hpp>
 #include <djinterop/semantic_version.hpp>
 
@@ -90,10 +90,10 @@ public:
     void set_adjusted_main_cue(double sample_offset) const;
 
     /// Returns the album name (metadata) of the track
-    std::optional<std::string> album() const;
+    stdx::optional<std::string> album() const;
 
     /// Sets the album name (metadata) of the track
-    void set_album(std::optional<std::string> album) const;
+    void set_album(stdx::optional<std::string> album) const;
     void set_album(std::string album) const;
 
     /// Returns the ID of the `album_art` associated to the track
@@ -101,51 +101,51 @@ public:
     /// If the track doesn't have an associated `album_art`, then `nullopt`
     /// is returned.
     /// TODO (haslersn): Return an `album_art` object instead.
-    std::optional<int64_t> album_art_id() const;
+    stdx::optional<int64_t> album_art_id() const;
 
     /// Sets the ID of the `album_art` associated to the track
     /// TODO (haslersn): Pass an `album_art` object instead.
-    void set_album_art_id(std::optional<int64_t> album_art_id) const;
+    void set_album_art_id(stdx::optional<int64_t> album_art_id) const;
     void set_album_art_id(int64_t album_art_id) const;
 
     /// Returns the artist (metadata) of the track
-    std::optional<std::string> artist() const;
+    stdx::optional<std::string> artist() const;
 
     /// Sets the artist (metadata) of the track
-    void set_artist(std::optional<std::string> artist) const;
+    void set_artist(stdx::optional<std::string> artist) const;
     void set_artist(std::string artist) const;
 
-    std::optional<double> average_loudness() const;
+    stdx::optional<double> average_loudness() const;
 
-    void set_average_loudness(std::optional<double> average_loudness) const;
+    void set_average_loudness(stdx::optional<double> average_loudness) const;
     void set_average_loudness(double average_loudness) const;
 
     /// Returns the bitrate (metadata) of the track
-    std::optional<int64_t> bitrate() const;
+    stdx::optional<int64_t> bitrate() const;
 
     /// Sets the bitrate (metadata) of the track
-    void set_bitrate(std::optional<int64_t> bitrate) const;
+    void set_bitrate(stdx::optional<int64_t> bitrate) const;
     void set_bitrate(int64_t bitrate) const;
 
     /// Returns the BPM (metadata) of the track, rounded to the nearest integer
-    std::optional<double> bpm() const;
+    stdx::optional<double> bpm() const;
 
     /// Sets the BPM (metadata) of the track, rounded to the nearest integer
-    void set_bpm(std::optional<double> bpm) const;
+    void set_bpm(stdx::optional<double> bpm) const;
     void set_bpm(double bpm) const;
 
     /// Returns the comment associated to the track (metadata)
-    std::optional<std::string> comment() const;
+    stdx::optional<std::string> comment() const;
 
     /// Sets the comment associated to the track (metadata)
-    void set_comment(std::optional<std::string> comment) const;
+    void set_comment(stdx::optional<std::string> comment) const;
     void set_comment(std::string comment) const;
 
     /// Returns the composer (metadata) of the track
-    std::optional<std::string> composer() const;
+    stdx::optional<std::string> composer() const;
 
     /// Sets the composer (metadata) of the track
-    void set_composer(std::optional<std::string> composer) const;
+    void set_composer(stdx::optional<std::string> composer) const;
     void set_composer(std::string composer) const;
 
     /// Returns the crates containing the track
@@ -163,7 +163,7 @@ public:
     void set_default_main_cue(double sample_offset) const;
 
     /// Returns the duration (metadata) of the track
-    std::optional<std::chrono::milliseconds> duration() const;
+    stdx::optional<std::chrono::milliseconds> duration() const;
 
     /// Returns the file extension part of `track::relative_path()`
     ///
@@ -175,20 +175,20 @@ public:
     std::string filename() const;
 
     /// Returns the genre (metadata) of the track
-    std::optional<std::string> genre() const;
+    stdx::optional<std::string> genre() const;
 
     /// Sets the genre (metadata) of the track
-    void set_genre(std::optional<std::string> genre) const;
+    void set_genre(stdx::optional<std::string> genre) const;
     void set_genre(std::string genre) const;
 
-    std::optional<hot_cue> hot_cue_at(int32_t index) const;
+    stdx::optional<hot_cue> hot_cue_at(int32_t index) const;
 
-    void set_hot_cue_at(int32_t index, std::optional<hot_cue> cue) const;
+    void set_hot_cue_at(int32_t index, stdx::optional<hot_cue> cue) const;
     void set_hot_cue_at(int32_t index, hot_cue cue) const;
 
-    std::array<std::optional<hot_cue>, 8> hot_cues() const;
+    std::array<stdx::optional<hot_cue>, 8> hot_cues() const;
 
-    void set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) const;
+    void set_hot_cues(std::array<stdx::optional<hot_cue>, 8> cues) const;
 
     /// Returns the ID of this track
     ///
@@ -197,33 +197,33 @@ public:
     int64_t id() const;
 
     /// TODO (haslersn): Document this method.
-    std::optional<track_import_info> import_info() const;
+    stdx::optional<track_import_info> import_info() const;
 
     /// TODO (haslersn): Document these methods.
     void set_import_info(
-        const std::optional<track_import_info>& import_info) const;
+        const stdx::optional<track_import_info>& import_info) const;
     void set_import_info(const track_import_info& import_info) const;
 
     /// Returns `true` iff `*this` is valid as described in the class comment
     bool is_valid() const;
 
     /// Returns the key (metadata) of the track
-    std::optional<musical_key> key() const;
+    stdx::optional<musical_key> key() const;
 
     /// Sets the key (metadata) of the track
-    void set_key(std::optional<musical_key> key) const;
+    void set_key(stdx::optional<musical_key> key) const;
     void set_key(musical_key key) const;
 
     /// Get the time at which this track was last accessed
     ///
     /// Note that on VFAT filesystems, the access time is ceiled to just a date,
     /// and loses any time precision.
-    std::optional<std::chrono::system_clock::time_point> last_accessed_at()
+    stdx::optional<std::chrono::system_clock::time_point> last_accessed_at()
         const;
 
     /// TODO (haslersn): Document these methods.
     void set_last_accessed_at(
-        std::optional<std::chrono::system_clock::time_point> last_accessed_at)
+        stdx::optional<std::chrono::system_clock::time_point> last_accessed_at)
         const;
     void set_last_accessed_at(
         std::chrono::system_clock::time_point last_accessed_at) const;
@@ -232,40 +232,41 @@ public:
     ///
     /// Note that this is the attribute modification time, not the data
     /// modification time, i.e. ctime not mtime.
-    std::optional<std::chrono::system_clock::time_point> last_modified_at()
+    stdx::optional<std::chrono::system_clock::time_point> last_modified_at()
         const;
 
     /// TODO (haslersn): Document these methods.
     void set_last_modified_at(
-        std::optional<std::chrono::system_clock::time_point> last_modified_at)
+        stdx::optional<std::chrono::system_clock::time_point> last_modified_at)
         const;
     void set_last_modified_at(
         std::chrono::system_clock::time_point last_modified_at) const;
 
     /// Returns the time at which the track was last played
-    std::optional<std::chrono::system_clock::time_point> last_played_at() const;
+    stdx::optional<std::chrono::system_clock::time_point> last_played_at()
+        const;
 
     /// Sets the time at which the track was last played
     void set_last_played_at(
-        std::optional<std::chrono::system_clock::time_point> time) const;
+        stdx::optional<std::chrono::system_clock::time_point> time) const;
     void set_last_played_at(std::chrono::system_clock::time_point time) const;
 
-    std::optional<loop> loop_at(int32_t index) const;
+    stdx::optional<loop> loop_at(int32_t index) const;
 
-    void set_loop_at(int32_t index, std::optional<loop> l) const;
+    void set_loop_at(int32_t index, stdx::optional<loop> l) const;
     void set_loop_at(int32_t index, loop l) const;
 
-    std::array<std::optional<loop>, 8> loops() const;
+    std::array<stdx::optional<loop>, 8> loops() const;
 
-    void set_loops(std::array<std::optional<loop>, 8> loops) const;
+    void set_loops(std::array<stdx::optional<loop>, 8> loops) const;
 
     std::vector<waveform_entry> overview_waveform() const;
 
     /// Returns the publisher (metadata) of the track
-    std::optional<std::string> publisher() const;
+    stdx::optional<std::string> publisher() const;
 
     /// Sets the publisher (metadata) of the track
-    void set_publisher(std::optional<std::string> publisher) const;
+    void set_publisher(stdx::optional<std::string> publisher) const;
     void set_publisher(std::string publisher) const;
 
     /// Get the required number of samples per waveform entry.
@@ -284,23 +285,23 @@ public:
     /// TODO (haslersn): Document this method.
     void set_relative_path(std::string relative_path) const;
 
-    std::optional<sampling_info> sampling() const;
+    stdx::optional<sampling_info> sampling() const;
 
-    void set_sampling(std::optional<sampling_info> sample_rate) const;
+    void set_sampling(stdx::optional<sampling_info> sample_rate) const;
     void set_sampling(sampling_info sample_rate) const;
 
     /// Returns the title (metadata) of the track
-    std::optional<std::string> title() const;
+    stdx::optional<std::string> title() const;
 
     /// Sets the title (metadata) of the track
-    void set_title(std::optional<std::string> title) const;
+    void set_title(stdx::optional<std::string> title) const;
     void set_title(std::string title) const;
 
     /// Returns the track number (metadata) of the track
-    std::optional<int32_t> track_number() const;
+    stdx::optional<int32_t> track_number() const;
 
     /// Sets the track number (metadata) of the track
-    void set_track_number(std::optional<int32_t> track_number) const;
+    void set_track_number(stdx::optional<int32_t> track_number) const;
     void set_track_number(int32_t track_number) const;
 
     std::vector<waveform_entry> waveform() const;
@@ -308,10 +309,10 @@ public:
     void set_waveform(std::vector<waveform_entry> waveform) const;
 
     /// Returns the recording year (metadata) of the track
-    std::optional<int32_t> year() const;
+    stdx::optional<int32_t> year() const;
 
     /// Sets the recording year (metadata) of the track
-    void set_year(std::optional<int32_t> year) const;
+    void set_year(stdx::optional<int32_t> year) const;
     void set_year(int32_t year) const;
 
     // TODO (haslersn): non public?

--- a/include/meson.build
+++ b/include/meson.build
@@ -9,6 +9,7 @@ djinterop_header_files = [
     'djinterop/exceptions.hpp',
     'djinterop/enginelibrary.hpp',
     'djinterop/musical_key.hpp',
+    'djinterop/optional.hpp',
     'djinterop/pad_color.hpp',
     'djinterop/performance_data.hpp',
     'djinterop/semantic_version.hpp',

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,6 +1,8 @@
+# Used only to generate config.hpp in the nested include dir.
+subdir('djinterop')
+
 djinterop_header_files = [
     'djinterop/album_art.hpp',
-    'djinterop/config.hpp',
     'djinterop/crate.hpp',
     'djinterop/database.hpp',
     'djinterop/djinterop.hpp',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'djinterop',
     'cpp', 'c',
-    version: '0.11.0',
+    version: '0.12.0',
     license: 'LGPL-3.0',
     default_options: ['cpp_std=c++17', 'default_library=both'])
 

--- a/src/djinterop/crate.cpp
+++ b/src/djinterop/crate.cpp
@@ -80,7 +80,7 @@ std::string crate::name() const
     return pimpl_->name();
 }
 
-std::optional<crate> crate::parent() const
+stdx::optional<crate> crate::parent() const
 {
     return pimpl_->parent();
 }
@@ -95,13 +95,12 @@ void crate::set_name(std::string name) const
     pimpl_->set_name(name);
 }
 
-void crate::set_parent(std::optional<crate> parent) const
+void crate::set_parent(stdx::optional<crate> parent) const
 {
     pimpl_->set_parent(parent);
 }
 
-std::optional<crate> crate::sub_crate_by_name(
-    const std::string& name) const
+stdx::optional<crate> crate::sub_crate_by_name(const std::string& name) const
 {
     return pimpl_->sub_crate_by_name(name);
 }

--- a/src/djinterop/database.cpp
+++ b/src/djinterop/database.cpp
@@ -37,7 +37,7 @@ transaction_guard database::begin_transaction() const
     return pimpl_->begin_transaction();
 }
 
-std::optional<crate> database::crate_by_id(int64_t id) const
+stdx::optional<crate> database::crate_by_id(int64_t id) const
 {
     return pimpl_->crate_by_id(id);
 }
@@ -92,13 +92,13 @@ std::vector<crate> database::root_crates() const
     return pimpl_->root_crates();
 }
 
-std::optional<crate> database::root_crate_by_name(
+stdx::optional<crate> database::root_crate_by_name(
     const std::string& name) const
 {
     return pimpl_->root_crate_by_name(name);
 }
 
-std::optional<track> database::track_by_id(int64_t id) const
+stdx::optional<track> database::track_by_id(int64_t id) const
 {
     return pimpl_->track_by_id(id);
 }

--- a/src/djinterop/enginelibrary/el_crate_impl.cpp
+++ b/src/djinterop/enginelibrary/el_crate_impl.cpp
@@ -54,7 +54,6 @@ using djinterop::track;
 //     relationship is not written to this table.
 namespace
 {
-
 void update_path(
     sqlite::database& music_db, crate cr, const std::string& parent_path)
 {
@@ -85,8 +84,8 @@ void ensure_valid_name(const std::string& name)
 
 }  // namespace
 
-el_crate_impl::el_crate_impl(std::shared_ptr<el_storage> storage, int64_t id)
-    : crate_impl{id}, storage_{std::move(storage)}
+el_crate_impl::el_crate_impl(std::shared_ptr<el_storage> storage, int64_t id) :
+    crate_impl{id}, storage_{std::move(storage)}
 {
 }
 
@@ -133,9 +132,7 @@ crate el_crate_impl::create_sub_crate(std::string name)
     el_transaction_guard_impl trans{storage_};
 
     std::string path;
-    storage_->db
-            << "SELECT path FROM Crate WHERE id = ?"
-            << id() >>
+    storage_->db << "SELECT path FROM Crate WHERE id = ?" << id() >>
         [&](std::string path_val) {
             if (path.empty())
             {
@@ -157,13 +154,12 @@ crate el_crate_impl::create_sub_crate(std::string name)
                     "crateParentId) VALUES (?, ?)"
                  << sub_id << id();
 
-    storage_->db
-        << "INSERT INTO CrateHierarchy (crateId, crateIdChild) "
-           "SELECT crateId, ? FROM CrateHierarchy "
-           "WHERE crateIdChild = ? "
-           "UNION "
-           "SELECT ? AS crateId, ? AS crateIdChild"
-        << sub_id << id() << id() << sub_id;
+    storage_->db << "INSERT INTO CrateHierarchy (crateId, crateIdChild) "
+                    "SELECT crateId, ? FROM CrateHierarchy "
+                    "WHERE crateIdChild = ? "
+                    "UNION "
+                    "SELECT ? AS crateId, ? AS crateIdChild"
+                 << sub_id << id() << id() << sub_id;
 
     crate cr{std::make_shared<el_crate_impl>(storage_, sub_id)};
 
@@ -211,7 +207,7 @@ bool el_crate_impl::is_valid()
 
 std::string el_crate_impl::name()
 {
-    std::optional<std::string> name;
+    stdx::optional<std::string> name;
     storage_->db << "SELECT title FROM Crate WHERE id = ?" << id() >>
         [&](std::string title) {
             if (!name)
@@ -231,9 +227,9 @@ std::string el_crate_impl::name()
     return *name;
 }
 
-std::optional<crate> el_crate_impl::parent()
+stdx::optional<crate> el_crate_impl::parent()
 {
-    std::optional<crate> parent;
+    stdx::optional<crate> parent;
     storage_->db
             << "SELECT crateParentId FROM CrateParentList WHERE crateOriginId "
                "= ? AND crateParentId <> crateOriginId"
@@ -298,7 +294,7 @@ void el_crate_impl::set_name(std::string name)
     trans.commit();
 }
 
-void el_crate_impl::set_parent(std::optional<crate> parent)
+void el_crate_impl::set_parent(stdx::optional<crate> parent)
 {
     el_transaction_guard_impl trans{storage_};
 
@@ -323,9 +319,9 @@ void el_crate_impl::set_parent(std::optional<crate> parent)
     trans.commit();
 }
 
-std::optional<crate> el_crate_impl::sub_crate_by_name(const std::string& name)
+stdx::optional<crate> el_crate_impl::sub_crate_by_name(const std::string& name)
 {
-    std::optional<crate> cr;
+    stdx::optional<crate> cr;
     storage_->db << "SELECT cr.id FROM Crate cr "
                     "JOIN CrateParentList cpl ON (cpl.crateOriginId = cr.id) "
                     "WHERE cr.title = ? "

--- a/src/djinterop/enginelibrary/el_crate_impl.hpp
+++ b/src/djinterop/enginelibrary/el_crate_impl.hpp
@@ -41,11 +41,11 @@ public:
     std::vector<crate> descendants() override;
     bool is_valid() override;
     std::string name() override;
-    std::optional<crate> parent() override;
+    stdx::optional<crate> parent() override;
     void remove_track(track tr) override;
     void set_name(std::string name) override;
-    void set_parent(std::optional<crate> parent) override;
-    std::optional<crate> sub_crate_by_name(const std::string& name) override;
+    void set_parent(stdx::optional<crate> parent) override;
+    stdx::optional<crate> sub_crate_by_name(const std::string& name) override;
     std::vector<track> tracks() override;
 
 private:

--- a/src/djinterop/enginelibrary/el_database_impl.cpp
+++ b/src/djinterop/enginelibrary/el_database_impl.cpp
@@ -50,17 +50,16 @@ void ensure_valid_crate_name(const std::string& name)
 
 }  // namespace
 
-
-el_database_impl::el_database_impl(std::string directory)
-    : storage_{std::make_shared<el_storage>(std::move(directory))}
+el_database_impl::el_database_impl(std::string directory) :
+    storage_{std::make_shared<el_storage>(std::move(directory))}
 {
     // TODO (haslersn): On construction, should we check that the database
     // version is supported? This would give more guarantees to a user that
     // obtains a database object.
 }
 
-el_database_impl::el_database_impl(std::shared_ptr<el_storage> storage)
-    : storage_{std::move(storage)}
+el_database_impl::el_database_impl(std::shared_ptr<el_storage> storage) :
+    storage_{std::move(storage)}
 {
 }
 
@@ -70,9 +69,9 @@ transaction_guard el_database_impl::begin_transaction()
         std::make_unique<el_transaction_guard_impl>(storage_)};
 }
 
-std::optional<crate> el_database_impl::crate_by_id(int64_t id)
+stdx::optional<crate> el_database_impl::crate_by_id(int64_t id)
 {
-    std::optional<crate> cr;
+    stdx::optional<crate> cr;
     storage_->db << "SELECT COUNT(*) FROM Crate WHERE id = ?" << id >>
         [&](int64_t count) {
             if (count == 1)
@@ -162,7 +161,7 @@ track el_database_impl::create_track(std::string relative_path)
             << "REPLACE INTO MetaData (id, type, text) VALUES (?, ?, ?)";
         for (int64_t type : {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 16})
         {
-            std::optional<std::string> text;
+            stdx::optional<std::string> text;
             switch (type)
             {
                 case 10:
@@ -193,7 +192,7 @@ track el_database_impl::create_track(std::string relative_path)
                                         "type, value) VALUES (?, ?, ?)";
         for (int64_t type = 1; type <= 11 /* 12 */; ++type)
         {
-            std::optional<int64_t> value;
+            stdx::optional<int64_t> value;
             switch (type)
             {
                 case 5: value = 0; break;
@@ -258,9 +257,10 @@ std::vector<crate> el_database_impl::root_crates()
     return results;
 }
 
-std::optional<crate> el_database_impl::root_crate_by_name(const std::string& name)
+stdx::optional<crate> el_database_impl::root_crate_by_name(
+    const std::string& name)
 {
-    std::optional<crate> cr;
+    stdx::optional<crate> cr;
     storage_->db << "SELECT cr.id FROM Crate cr "
                     "JOIN CrateParentList cpl ON (cpl.crateOriginId = cr.id) "
                     "WHERE cr.title = ? "
@@ -273,9 +273,9 @@ std::optional<crate> el_database_impl::root_crate_by_name(const std::string& nam
     return cr;
 }
 
-std::optional<track> el_database_impl::track_by_id(int64_t id)
+stdx::optional<track> el_database_impl::track_by_id(int64_t id)
 {
-    std::optional<track> tr;
+    stdx::optional<track> tr;
     storage_->db << "SELECT COUNT(*) FROM Track WHERE id = ?" << id >>
         [&](int64_t count) {
             if (count == 1)

--- a/src/djinterop/enginelibrary/el_database_impl.hpp
+++ b/src/djinterop/enginelibrary/el_database_impl.hpp
@@ -33,7 +33,7 @@ public:
     el_database_impl(std::shared_ptr<el_storage> storage);
 
     transaction_guard begin_transaction() override;
-    std::optional<djinterop::crate> crate_by_id(int64_t id) override;
+    stdx::optional<djinterop::crate> crate_by_id(int64_t id) override;
     std::vector<djinterop::crate> crates() override;
     std::vector<djinterop::crate> crates_by_name(
         const std::string& name) override;
@@ -45,9 +45,9 @@ public:
     void remove_crate(djinterop::crate cr) override;
     void remove_track(djinterop::track tr) override;
     std::vector<djinterop::crate> root_crates() override;
-    std::optional<djinterop::crate> root_crate_by_name(
+    stdx::optional<djinterop::crate> root_crate_by_name(
         const std::string& name) override;
-    std::optional<djinterop::track> track_by_id(int64_t id) override;
+    stdx::optional<djinterop::track> track_by_id(int64_t id) override;
     std::vector<djinterop::track> tracks() override;
     std::vector<djinterop::track> tracks_by_relative_path(
         const std::string& relative_path) override;

--- a/src/djinterop/enginelibrary/el_track_impl.cpp
+++ b/src/djinterop/enginelibrary/el_track_impl.cpp
@@ -417,7 +417,6 @@ void el_track_impl::set_default_main_cue(double sample_offset)
 
 stdx::optional<milliseconds> el_track_impl::duration()
 {
-    stdx::optional<milliseconds> result;
     auto smp = sampling();
     if (smp)
     {

--- a/src/djinterop/enginelibrary/el_track_impl.cpp
+++ b/src/djinterop/enginelibrary/el_track_impl.cpp
@@ -37,10 +37,10 @@ using std::chrono::system_clock;
 
 namespace
 {
-std::optional<system_clock::time_point> to_time_point(
-    std::optional<int64_t> timestamp)
+stdx::optional<system_clock::time_point> to_time_point(
+    stdx::optional<int64_t> timestamp)
 {
-    std::optional<system_clock::time_point> result;
+    stdx::optional<system_clock::time_point> result;
     if (timestamp)
     {
         result = system_clock::time_point{seconds(*timestamp)};
@@ -48,10 +48,10 @@ std::optional<system_clock::time_point> to_time_point(
     return result;
 }
 
-std::optional<int64_t> to_timestamp(
-    std::optional<system_clock::time_point> time)
+stdx::optional<int64_t> to_timestamp(
+    stdx::optional<system_clock::time_point> time)
 {
-    std::optional<int64_t> result;
+    stdx::optional<int64_t> result;
     if (time)
     {
         result = duration_cast<seconds>(time->time_since_epoch()).count();
@@ -59,7 +59,8 @@ std::optional<int64_t> to_timestamp(
     return result;
 }
 
-/// Calculate the quantisation number for waveforms, given a quantisation number.
+/// Calculate the quantisation number for waveforms, given a quantisation
+/// number.
 ///
 /// A few numbers written to the waveform performance data are rounded
 /// to multiples of a particular "quantisation number", that is equal to
@@ -76,7 +77,7 @@ int64_t quantisation_number(int64_t sample_rate)
 /// that each one represents must be calculated from the true sample count by
 /// rounding the number of samples to the quantisation number first.
 int64_t calculate_overview_waveform_samples_per_entry(
-        int64_t sample_rate, int64_t sample_count)
+    int64_t sample_rate, int64_t sample_count)
 {
     auto qn = quantisation_number(sample_rate);
     return ((sample_count / qn) * qn) / 1024;
@@ -84,15 +85,15 @@ int64_t calculate_overview_waveform_samples_per_entry(
 
 }  // namespace
 
-el_track_impl::el_track_impl(std::shared_ptr<el_storage> storage, int64_t id)
-    : track_impl{id}, storage_{std::move(storage)}
+el_track_impl::el_track_impl(std::shared_ptr<el_storage> storage, int64_t id) :
+    track_impl{id}, storage_{std::move(storage)}
 {
 }
 
-std::optional<std::string> el_track_impl::get_metadata_str(
+stdx::optional<std::string> el_track_impl::get_metadata_str(
     metadata_str_type type)
 {
-    std::optional<std::string> result;
+    stdx::optional<std::string> result;
     storage_->db << "SELECT text FROM MetaData WHERE id = ? AND "
                     "type = ? AND text IS NOT NULL"
                  << id() << static_cast<int64_t>(type) >>
@@ -113,7 +114,7 @@ std::optional<std::string> el_track_impl::get_metadata_str(
 }
 
 void el_track_impl::set_metadata_str(
-    metadata_str_type type, std::optional<std::string> content)
+    metadata_str_type type, stdx::optional<std::string> content)
 {
     if (content)
     {
@@ -134,9 +135,9 @@ void el_track_impl::set_metadata_str(
                  << id() << static_cast<int64_t>(type) << content;
 }
 
-std::optional<int64_t> el_track_impl::get_metadata_int(metadata_int_type type)
+stdx::optional<int64_t> el_track_impl::get_metadata_int(metadata_int_type type)
 {
-    std::optional<int64_t> result;
+    stdx::optional<int64_t> result;
     storage_->db << "SELECT value FROM MetaDataInteger WHERE id = "
                     "? AND type = ? AND value IS NOT NULL"
                  << id() << static_cast<int64_t>(type) >>
@@ -157,7 +158,7 @@ std::optional<int64_t> el_track_impl::get_metadata_int(metadata_int_type type)
 }
 
 void el_track_impl::set_metadata_int(
-    metadata_int_type type, std::optional<int64_t> content)
+    metadata_int_type type, stdx::optional<int64_t> content)
 {
     storage_->db
         << "REPLACE INTO MetaDataInteger (id, type, value) VALUES (?, ?, ?)"
@@ -262,20 +263,20 @@ void el_track_impl::set_adjusted_main_cue(double sample_offset)
     trans.commit();
 }
 
-std::optional<std::string> el_track_impl::album()
+stdx::optional<std::string> el_track_impl::album()
 {
     return get_metadata_str(metadata_str_type::album);
 }
 
-void el_track_impl::set_album(std::optional<std::string> album)
+void el_track_impl::set_album(stdx::optional<std::string> album)
 {
     set_metadata_str(metadata_str_type::album, album);
 }
 
-std::optional<int64_t> el_track_impl::album_art_id()
+stdx::optional<int64_t> el_track_impl::album_art_id()
 {
     int64_t cell = get_cell<int64_t>("idAlbumArt");
-    std::optional<int64_t> album_art_id;
+    stdx::optional<int64_t> album_art_id;
     if (cell < 1)
     {
         // TODO (haslersn): Throw something.
@@ -287,7 +288,7 @@ std::optional<int64_t> el_track_impl::album_art_id()
     return album_art_id;
 }
 
-void el_track_impl::set_album_art_id(std::optional<int64_t> album_art_id)
+void el_track_impl::set_album_art_id(stdx::optional<int64_t> album_art_id)
 {
     if (album_art_id && *album_art_id <= 1)
     {
@@ -297,23 +298,23 @@ void el_track_impl::set_album_art_id(std::optional<int64_t> album_art_id)
     // 1 is the magic number for "no album art"
 }
 
-std::optional<std::string> el_track_impl::artist()
+stdx::optional<std::string> el_track_impl::artist()
 {
     return get_metadata_str(metadata_str_type::artist);
 }
 
-void el_track_impl::set_artist(std::optional<std::string> artist)
+void el_track_impl::set_artist(stdx::optional<std::string> artist)
 {
     set_metadata_str(metadata_str_type::artist, artist);
 }
 
-std::optional<double> el_track_impl::average_loudness()
+stdx::optional<double> el_track_impl::average_loudness()
 {
     return get_track_data().average_loudness;
 }
 
 void el_track_impl::set_average_loudness(
-    std::optional<double> average_loudness)
+    stdx::optional<double> average_loudness)
 {
     el_transaction_guard_impl trans{storage_};
     auto track_d = get_track_data();
@@ -322,25 +323,25 @@ void el_track_impl::set_average_loudness(
     trans.commit();
 }
 
-std::optional<int64_t> el_track_impl::bitrate()
+stdx::optional<int64_t> el_track_impl::bitrate()
 {
-    return get_cell<std::optional<int64_t>>("bitrate");
+    return get_cell<stdx::optional<int64_t> >("bitrate");
 }
 
-void el_track_impl::set_bitrate(std::optional<int64_t> bitrate)
+void el_track_impl::set_bitrate(stdx::optional<int64_t> bitrate)
 {
     set_cell("bitrate", bitrate);
 }
 
-std::optional<double> el_track_impl::bpm()
+stdx::optional<double> el_track_impl::bpm()
 {
-    return get_cell<std::optional<double>>("bpmAnalyzed");
+    return get_cell<stdx::optional<double> >("bpmAnalyzed");
 }
 
-void el_track_impl::set_bpm(std::optional<double> bpm)
+void el_track_impl::set_bpm(stdx::optional<double> bpm)
 {
     set_cell("bpmAnalyzed", bpm);
-    std::optional<int64_t> ceiled_bpm;
+    stdx::optional<int64_t> ceiled_bpm;
     if (bpm)
     {
         ceiled_bpm = static_cast<int64_t>(std::ceil(*bpm));
@@ -348,22 +349,22 @@ void el_track_impl::set_bpm(std::optional<double> bpm)
     set_cell("bpm", ceiled_bpm);
 }
 
-std::optional<std::string> el_track_impl::comment()
+stdx::optional<std::string> el_track_impl::comment()
 {
     return get_metadata_str(metadata_str_type::comment);
 }
 
-void el_track_impl::set_comment(std::optional<std::string> comment)
+void el_track_impl::set_comment(stdx::optional<std::string> comment)
 {
     set_metadata_str(metadata_str_type::comment, comment);
 }
 
-std::optional<std::string> el_track_impl::composer()
+stdx::optional<std::string> el_track_impl::composer()
 {
     return get_metadata_str(metadata_str_type::composer);
 }
 
-void el_track_impl::set_composer(std::optional<std::string> composer)
+void el_track_impl::set_composer(stdx::optional<std::string> composer)
 {
     set_metadata_str(metadata_str_type::composer, composer);
 }
@@ -414,28 +415,27 @@ void el_track_impl::set_default_main_cue(double sample_offset)
     trans.commit();
 }
 
-std::optional<milliseconds> el_track_impl::duration()
+stdx::optional<milliseconds> el_track_impl::duration()
 {
-    std::optional<milliseconds> result;
+    stdx::optional<milliseconds> result;
     auto smp = sampling();
     if (smp)
     {
         double secs = smp->sample_count / smp->sample_rate;
         return milliseconds{static_cast<int64_t>(1000 * secs)};
     }
-    auto secs = get_cell<std::optional<int64_t>>("length");
+    auto secs = get_cell<stdx::optional<int64_t> >("length");
     if (secs)
     {
         return milliseconds{*secs * 1000};
     }
-    return std::nullopt;
+    return stdx::nullopt;
 }
 
 std::string el_track_impl::file_extension()
 {
     auto rel_path = relative_path();
-    return get_file_extension(rel_path)
-        .value_or(std::string{});
+    return get_file_extension(rel_path).value_or(std::string{});
 }
 
 std::string el_track_impl::filename()
@@ -444,23 +444,23 @@ std::string el_track_impl::filename()
     return get_filename(rel_path);
 }
 
-std::optional<std::string> el_track_impl::genre()
+stdx::optional<std::string> el_track_impl::genre()
 {
     return get_metadata_str(metadata_str_type::genre);
 }
 
-void el_track_impl::set_genre(std::optional<std::string> genre)
+void el_track_impl::set_genre(stdx::optional<std::string> genre)
 {
     set_metadata_str(metadata_str_type::genre, genre);
 }
 
-std::optional<hot_cue> el_track_impl::hot_cue_at(int32_t index)
+stdx::optional<hot_cue> el_track_impl::hot_cue_at(int32_t index)
 {
     auto quick_cues_d = get_quick_cues_data();
     return std::move(quick_cues_d.hot_cues[index]);
 }
 
-void el_track_impl::set_hot_cue_at(int32_t index, std::optional<hot_cue> cue)
+void el_track_impl::set_hot_cue_at(int32_t index, stdx::optional<hot_cue> cue)
 {
     el_transaction_guard_impl trans{storage_};
     auto quick_cues_d = get_quick_cues_data();
@@ -469,13 +469,13 @@ void el_track_impl::set_hot_cue_at(int32_t index, std::optional<hot_cue> cue)
     trans.commit();
 }
 
-std::array<std::optional<hot_cue>, 8> el_track_impl::hot_cues()
+std::array<stdx::optional<hot_cue>, 8> el_track_impl::hot_cues()
 {
     auto quick_cues_d = get_quick_cues_data();
     return std::move(quick_cues_d.hot_cues);
 }
 
-void el_track_impl::set_hot_cues(std::array<std::optional<hot_cue>, 8> cues)
+void el_track_impl::set_hot_cues(std::array<stdx::optional<hot_cue>, 8> cues)
 {
     el_transaction_guard_impl trans{storage_};
     // TODO (haslersn): The following can be optimized because in this case we
@@ -486,20 +486,21 @@ void el_track_impl::set_hot_cues(std::array<std::optional<hot_cue>, 8> cues)
     trans.commit();
 }
 
-std::optional<track_import_info> el_track_impl::import_info()
+stdx::optional<track_import_info> el_track_impl::import_info()
 {
     if (get_cell<int64_t>("isExternalTrack") == 0)
     {
-        return std::nullopt;
+        return stdx::nullopt;
     }
-    return track_import_info{get_cell<std::string>("uuidOfExternalDatabase"),
-                             get_cell<int64_t>("idTrackInExternalDatabase")};
+    return track_import_info{
+        get_cell<std::string>("uuidOfExternalDatabase"),
+        get_cell<int64_t>("idTrackInExternalDatabase")};
     // TODO (haslersn): How should we handle cells that unexpectedly don't
     // contain integral values?
 }
 
 void el_track_impl::set_import_info(
-    const std::optional<track_import_info>& import_info)
+    const stdx::optional<track_import_info>& import_info)
 {
     if (import_info)
     {
@@ -533,9 +534,9 @@ bool el_track_impl::is_valid()
     return valid;
 }
 
-std::optional<musical_key> el_track_impl::key()
+stdx::optional<musical_key> el_track_impl::key()
 {
-    std::optional<musical_key> result;
+    stdx::optional<musical_key> result;
     auto key_num = get_metadata_int(metadata_int_type::musical_key);
     if (key_num)
     {
@@ -544,9 +545,9 @@ std::optional<musical_key> el_track_impl::key()
     return result;
 }
 
-void el_track_impl::set_key(std::optional<musical_key> key)
+void el_track_impl::set_key(stdx::optional<musical_key> key)
 {
-    std::optional<int64_t> key_num;
+    stdx::optional<int64_t> key_num;
     if (key)
     {
         key_num = static_cast<int64_t>(*key);
@@ -560,7 +561,7 @@ void el_track_impl::set_key(std::optional<musical_key> key)
     trans.commit();
 }
 
-std::optional<system_clock::time_point> el_track_impl::last_accessed_at()
+stdx::optional<system_clock::time_point> el_track_impl::last_accessed_at()
 
 {
     // TODO (haslersn): Is there a difference between
@@ -571,7 +572,7 @@ std::optional<system_clock::time_point> el_track_impl::last_accessed_at()
 }
 
 void el_track_impl::set_last_accessed_at(
-    std::optional<system_clock::time_point> accessed_at)
+    stdx::optional<system_clock::time_point> accessed_at)
 {
     if (accessed_at)
     {
@@ -590,34 +591,34 @@ void el_track_impl::set_last_accessed_at(
     }
     else
     {
-        set_metadata_int(metadata_int_type::last_accessed_ts, std::nullopt);
+        set_metadata_int(metadata_int_type::last_accessed_ts, stdx::nullopt);
     }
 }
 
-std::optional<system_clock::time_point> el_track_impl::last_modified_at()
+stdx::optional<system_clock::time_point> el_track_impl::last_modified_at()
 
 {
     return to_time_point(get_metadata_int(metadata_int_type::last_modified_ts));
 }
 
 void el_track_impl::set_last_modified_at(
-    std::optional<system_clock::time_point> modified_at)
+    stdx::optional<system_clock::time_point> modified_at)
 {
     set_metadata_int(
         metadata_int_type::last_modified_ts, to_timestamp(modified_at));
 }
 
-std::optional<system_clock::time_point> el_track_impl::last_played_at()
+stdx::optional<system_clock::time_point> el_track_impl::last_played_at()
 
 {
     return to_time_point(get_metadata_int(metadata_int_type::last_played_ts));
 }
 
 void el_track_impl::set_last_played_at(
-    std::optional<system_clock::time_point> played_at)
+    stdx::optional<system_clock::time_point> played_at)
 {
-    static std::optional<std::string> zero{"0"};
-    static std::optional<std::string> one{"1"};
+    static stdx::optional<std::string> zero{"0"};
+    static stdx::optional<std::string> one{"1"};
     set_metadata_str(metadata_str_type::ever_played, played_at ? one : zero);
     set_metadata_int(
         metadata_int_type::last_played_ts, to_timestamp(played_at));
@@ -632,13 +633,13 @@ void el_track_impl::set_last_played_at(
     }
 }
 
-std::optional<loop> el_track_impl::loop_at(int32_t index)
+stdx::optional<loop> el_track_impl::loop_at(int32_t index)
 {
     auto loops_d = get_loops_data();
     return std::move(loops_d.loops[index]);
 }
 
-void el_track_impl::set_loop_at(int32_t index, std::optional<loop> l)
+void el_track_impl::set_loop_at(int32_t index, stdx::optional<loop> l)
 {
     el_transaction_guard_impl trans{storage_};
     auto loops_d = get_loops_data();
@@ -647,13 +648,13 @@ void el_track_impl::set_loop_at(int32_t index, std::optional<loop> l)
     trans.commit();
 }
 
-std::array<std::optional<loop>, 8> el_track_impl::loops()
+std::array<stdx::optional<loop>, 8> el_track_impl::loops()
 {
     auto loops_d = get_loops_data();
     return std::move(loops_d.loops);
 }
 
-void el_track_impl::set_loops(std::array<std::optional<loop>, 8> cues)
+void el_track_impl::set_loops(std::array<stdx::optional<loop>, 8> cues)
 {
     el_transaction_guard_impl trans{storage_};
     loops_data loops_d;
@@ -668,12 +669,12 @@ std::vector<waveform_entry> el_track_impl::overview_waveform()
     return std::move(overview_waveform_d.waveform);
 }
 
-std::optional<std::string> el_track_impl::publisher()
+stdx::optional<std::string> el_track_impl::publisher()
 {
     return get_metadata_str(metadata_str_type::publisher);
 }
 
-void el_track_impl::set_publisher(std::optional<std::string> publisher)
+void el_track_impl::set_publisher(stdx::optional<std::string> publisher)
 {
     set_metadata_str(metadata_str_type::publisher, publisher);
 }
@@ -687,8 +688,8 @@ int64_t el_track_impl::required_waveform_samples_per_entry()
     }
     if (smp->sample_rate <= 0)
     {
-        throw track_database_inconsistency{"Track has non-positive sample rate",
-                                           id()};
+        throw track_database_inconsistency{
+            "Track has non-positive sample rate", id()};
     }
 
     // In high-resolution waveforms, the samples-per-entry is the same as
@@ -711,16 +712,16 @@ void el_track_impl::set_relative_path(std::string relative_path)
     set_metadata_str(metadata_str_type::file_extension, extension);
 }
 
-std::optional<sampling_info> el_track_impl::sampling()
+stdx::optional<sampling_info> el_track_impl::sampling()
 {
     return get_track_data().sampling;
 }
 
-void el_track_impl::set_sampling(std::optional<sampling_info> sampling)
+void el_track_impl::set_sampling(stdx::optional<sampling_info> sampling)
 {
     el_transaction_guard_impl trans{storage_};
 
-    std::optional<int64_t> secs;
+    stdx::optional<int64_t> secs;
     if (sampling)
     {
         secs = static_cast<int64_t>(
@@ -733,12 +734,11 @@ void el_track_impl::set_sampling(std::optional<sampling_info> sampling)
         oss << ":";
         oss << (*secs % 60);
         auto str = oss.str();
-        set_metadata_str(
-            metadata_str_type::duration_mm_ss, std::string{str});
+        set_metadata_str(metadata_str_type::duration_mm_ss, std::string{str});
     }
     else
     {
-        set_metadata_str(metadata_str_type::duration_mm_ss, std::nullopt);
+        set_metadata_str(metadata_str_type::duration_mm_ss, stdx::nullopt);
     }
     set_cell("length", secs);
     set_cell("lengthCalculated", secs);
@@ -764,7 +764,8 @@ void el_track_impl::set_sampling(std::optional<sampling_info> sampling)
         // entry that is dependent on the sample rate.  If the sample rate is
         // genuinely changed using this method, note that the waveform is likely
         // to need to be updated as well afterwards.
-        high_res_waveform_d.samples_per_entry = quantisation_number(sample_rate);
+        high_res_waveform_d.samples_per_entry =
+            quantisation_number(sample_rate);
         set_high_res_waveform_data(std::move(high_res_waveform_d));
     }
 
@@ -774,29 +775,29 @@ void el_track_impl::set_sampling(std::optional<sampling_info> sampling)
         // the number of entries is always fixed.
         overview_waveform_d.samples_per_entry =
             calculate_overview_waveform_samples_per_entry(
-                    sample_rate, sample_count);
+                sample_rate, sample_count);
         set_overview_waveform_data(std::move(overview_waveform_d));
     }
 
     trans.commit();
 }
 
-std::optional<std::string> el_track_impl::title()
+stdx::optional<std::string> el_track_impl::title()
 {
     return get_metadata_str(metadata_str_type::title);
 }
 
-void el_track_impl::set_title(std::optional<std::string> title)
+void el_track_impl::set_title(stdx::optional<std::string> title)
 {
     set_metadata_str(metadata_str_type::title, title);
 }
 
-std::optional<int32_t> el_track_impl::track_number()
+stdx::optional<int32_t> el_track_impl::track_number()
 {
-    return get_cell<std::optional<int32_t>>("playOrder");
+    return get_cell<stdx::optional<int32_t> >("playOrder");
 }
 
-void el_track_impl::set_track_number(std::optional<int32_t> track_number)
+void el_track_impl::set_track_number(stdx::optional<int32_t> track_number)
 {
     set_cell("playOrder", track_number);
 }
@@ -823,8 +824,8 @@ void el_track_impl::set_waveform(std::vector<waveform_entry> waveform)
         // Calculate an overview waveform automatically.
         // Note that the overview waveform always has 1024 entries in it.
         overview_waveform_d.samples_per_entry =
-                calculate_overview_waveform_samples_per_entry(
-                        sample_rate, sample_count);
+            calculate_overview_waveform_samples_per_entry(
+                sample_rate, sample_count);
         overview_waveform_d.waveform.reserve(1024);
         for (int32_t i = 0; i < 1024; ++i)
         {
@@ -834,7 +835,8 @@ void el_track_impl::set_waveform(std::vector<waveform_entry> waveform)
 
         // Make the assumption that the client has respected the required number
         // of samples per entry when constructing the waveform.
-        high_res_waveform_d.samples_per_entry = quantisation_number(sample_rate);
+        high_res_waveform_d.samples_per_entry =
+            quantisation_number(sample_rate);
         high_res_waveform_d.waveform = std::move(waveform);
     }
 
@@ -844,12 +846,12 @@ void el_track_impl::set_waveform(std::vector<waveform_entry> waveform)
     trans.commit();
 }
 
-std::optional<int32_t> el_track_impl::year()
+stdx::optional<int32_t> el_track_impl::year()
 {
-    return get_cell<std::optional<int32_t>>("year");
+    return get_cell<stdx::optional<int32_t> >("year");
 }
 
-void el_track_impl::set_year(std::optional<int32_t> year)
+void el_track_impl::set_year(stdx::optional<int32_t> year)
 {
     set_cell("year", year);
 }

--- a/src/djinterop/enginelibrary/el_track_impl.hpp
+++ b/src/djinterop/enginelibrary/el_track_impl.hpp
@@ -19,7 +19,6 @@
 
 #include <chrono>
 #include <memory>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -29,6 +28,7 @@
 #include <djinterop/enginelibrary/performance_data_format.hpp>
 #include <djinterop/exceptions.hpp>
 #include <djinterop/impl/track_impl.hpp>
+#include <djinterop/optional.hpp>
 
 namespace djinterop
 {
@@ -67,18 +67,18 @@ class el_track_impl : public djinterop::track_impl
 public:
     el_track_impl(std::shared_ptr<el_storage> storage, int64_t id);
 
-    std::optional<std::string> get_metadata_str(metadata_str_type type);
+    stdx::optional<std::string> get_metadata_str(metadata_str_type type);
     void set_metadata_str(
-        metadata_str_type type, std::optional<std::string> content);
+        metadata_str_type type, stdx::optional<std::string> content);
     void set_metadata_str(metadata_str_type type, const std::string& content);
-    std::optional<int64_t> get_metadata_int(metadata_int_type type);
+    stdx::optional<int64_t> get_metadata_int(metadata_int_type type);
     void set_metadata_int(
-        metadata_int_type type, std::optional<int64_t> content);
+        metadata_int_type type, stdx::optional<int64_t> content);
 
     template <typename T>
     T get_cell(const char* column_name)
     {
-        std::optional<T> result;
+        stdx::optional<T> result;
         storage_->db << (std::string{"SELECT "} + column_name +
                          " FROM Track WHERE id = ?")
                      << id() >>
@@ -111,7 +111,7 @@ public:
     template <typename T>
     T get_perfdata(const char* column_name)
     {
-        std::optional<T> result;
+        stdx::optional<T> result;
         storage_->db << (std::string{"SELECT "} + column_name +
                          " From PerformanceData WHERE id = ?")
                      << id() >>
@@ -216,79 +216,78 @@ public:
     void set_adjusted_beatgrid(std::vector<beatgrid_marker> beatgrid) override;
     double adjusted_main_cue() override;
     void set_adjusted_main_cue(double sample_offset) override;
-    std::optional<std::string> album() override;
-    void set_album(std::optional<std::string> album) override;
-    std::optional<int64_t> album_art_id() override;
-    void set_album_art_id(std::optional<int64_t> album_art_id) override;
-    std::optional<std::string> artist() override;
-    void set_artist(std::optional<std::string> artist) override;
-    std::optional<double> average_loudness() override;
-    void set_average_loudness(
-        std::optional<double> average_loudness) override;
-    std::optional<int64_t> bitrate() override;
-    void set_bitrate(std::optional<int64_t> bitrate) override;
-    std::optional<double> bpm() override;
-    void set_bpm(std::optional<double> bpm) override;
-    std::optional<std::string> comment() override;
-    void set_comment(std::optional<std::string> comment) override;
-    std::optional<std::string> composer() override;
-    void set_composer(std::optional<std::string> composer) override;
+    stdx::optional<std::string> album() override;
+    void set_album(stdx::optional<std::string> album) override;
+    stdx::optional<int64_t> album_art_id() override;
+    void set_album_art_id(stdx::optional<int64_t> album_art_id) override;
+    stdx::optional<std::string> artist() override;
+    void set_artist(stdx::optional<std::string> artist) override;
+    stdx::optional<double> average_loudness() override;
+    void set_average_loudness(stdx::optional<double> average_loudness) override;
+    stdx::optional<int64_t> bitrate() override;
+    void set_bitrate(stdx::optional<int64_t> bitrate) override;
+    stdx::optional<double> bpm() override;
+    void set_bpm(stdx::optional<double> bpm) override;
+    stdx::optional<std::string> comment() override;
+    void set_comment(stdx::optional<std::string> comment) override;
+    stdx::optional<std::string> composer() override;
+    void set_composer(stdx::optional<std::string> composer) override;
     std::vector<djinterop::crate> containing_crates() override;
     database db() override;
     std::vector<beatgrid_marker> default_beatgrid() override;
     void set_default_beatgrid(std::vector<beatgrid_marker> beatgrid) override;
     double default_main_cue() override;
     void set_default_main_cue(double sample_offset) override;
-    std::optional<std::chrono::milliseconds> duration() override;
+    stdx::optional<std::chrono::milliseconds> duration() override;
     std::string file_extension() override;
     std::string filename() override;
-    std::optional<std::string> genre() override;
-    void set_genre(std::optional<std::string> genre) override;
-    std::optional<hot_cue> hot_cue_at(int32_t index) override;
-    void set_hot_cue_at(int32_t index, std::optional<hot_cue> cue) override;
-    std::array<std::optional<hot_cue>, 8> hot_cues() override;
-    void set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) override;
-    std::optional<track_import_info> import_info() override;
+    stdx::optional<std::string> genre() override;
+    void set_genre(stdx::optional<std::string> genre) override;
+    stdx::optional<hot_cue> hot_cue_at(int32_t index) override;
+    void set_hot_cue_at(int32_t index, stdx::optional<hot_cue> cue) override;
+    std::array<stdx::optional<hot_cue>, 8> hot_cues() override;
+    void set_hot_cues(std::array<stdx::optional<hot_cue>, 8> cues) override;
+    stdx::optional<track_import_info> import_info() override;
     void set_import_info(
-        const std::optional<track_import_info>& import_info) override;
+        const stdx::optional<track_import_info>& import_info) override;
     bool is_valid() override;
-    std::optional<musical_key> key() override;
-    void set_key(std::optional<musical_key> key) override;
-    std::optional<std::chrono::system_clock::time_point> last_accessed_at()
+    stdx::optional<musical_key> key() override;
+    void set_key(stdx::optional<musical_key> key) override;
+    stdx::optional<std::chrono::system_clock::time_point> last_accessed_at()
         override;
     void set_last_accessed_at(
-        std::optional<std::chrono::system_clock::time_point> accessed_at)
+        stdx::optional<std::chrono::system_clock::time_point> accessed_at)
         override;
-    std::optional<std::chrono::system_clock::time_point> last_modified_at()
+    stdx::optional<std::chrono::system_clock::time_point> last_modified_at()
         override;
     void set_last_modified_at(
-        std::optional<std::chrono::system_clock::time_point> modified_at)
+        stdx::optional<std::chrono::system_clock::time_point> modified_at)
         override;
-    std::optional<std::chrono::system_clock::time_point> last_played_at()
+    stdx::optional<std::chrono::system_clock::time_point> last_played_at()
         override;
     void set_last_played_at(
-        std::optional<std::chrono::system_clock::time_point> played_at)
+        stdx::optional<std::chrono::system_clock::time_point> played_at)
         override;
-    std::optional<loop> loop_at(int32_t index) override;
-    void set_loop_at(int32_t index, std::optional<loop> l) override;
-    std::array<std::optional<loop>, 8> loops() override;
-    void set_loops(std::array<std::optional<loop>, 8> cues) override;
+    stdx::optional<loop> loop_at(int32_t index) override;
+    void set_loop_at(int32_t index, stdx::optional<loop> l) override;
+    std::array<stdx::optional<loop>, 8> loops() override;
+    void set_loops(std::array<stdx::optional<loop>, 8> cues) override;
     std::vector<waveform_entry> overview_waveform() override;
-    std::optional<std::string> publisher() override;
-    void set_publisher(std::optional<std::string> publisher) override;
+    stdx::optional<std::string> publisher() override;
+    void set_publisher(stdx::optional<std::string> publisher) override;
     int64_t required_waveform_samples_per_entry() override;
     std::string relative_path() override;
     void set_relative_path(std::string relative_path) override;
-    std::optional<sampling_info> sampling() override;
-    void set_sampling(std::optional<sampling_info> sampling) override;
-    std::optional<std::string> title() override;
-    void set_title(std::optional<std::string> title) override;
-    std::optional<int32_t> track_number() override;
-    void set_track_number(std::optional<int32_t> track_number) override;
+    stdx::optional<sampling_info> sampling() override;
+    void set_sampling(stdx::optional<sampling_info> sampling) override;
+    stdx::optional<std::string> title() override;
+    void set_title(stdx::optional<std::string> title) override;
+    stdx::optional<int32_t> track_number() override;
+    void set_track_number(stdx::optional<int32_t> track_number) override;
     std::vector<waveform_entry> waveform() override;
     void set_waveform(std::vector<waveform_entry> waveform) override;
-    std::optional<int32_t> year() override;
-    void set_year(std::optional<int32_t> year) override;
+    stdx::optional<int32_t> year() override;
+    void set_year(stdx::optional<int32_t> year) override;
 
 private:
     std::shared_ptr<el_storage> storage_;

--- a/src/djinterop/enginelibrary/performance_data_format.cpp
+++ b/src/djinterop/enginelibrary/performance_data_format.cpp
@@ -18,13 +18,12 @@
 #include <chrono>
 #include <iomanip>
 #include <numeric>
-#include <optional>
-#include <string>
 #include <vector>
 
 #include <djinterop/enginelibrary/encode_decode_utils.hpp>
 #include <djinterop/enginelibrary/performance_data_format.hpp>
 #include <djinterop/musical_key.hpp>
+#include <djinterop/optional.hpp>
 
 typedef std::vector<char>::size_type data_size_t;
 
@@ -35,23 +34,23 @@ namespace enginelibrary
 namespace
 {
 template <typename T, typename U>
-std::optional<std::decay_t<T>> prohibit(const U& sentinel, T&& data)
+stdx::optional<std::decay_t<T> > prohibit(const U& sentinel, T&& data)
 {
     if (data == sentinel)
     {
-        return std::nullopt;
+        return stdx::nullopt;
     }
-    return std::make_optional(std::forward<T>(data));
+    return stdx::make_optional(std::forward<T>(data));
 }
 
 template <typename T, typename U>
-std::optional<T> opt_static_cast(const std::optional<U>& u)
+stdx::optional<T> opt_static_cast(const stdx::optional<U>& u)
 {
     if (!u)
     {
-        return std::nullopt;
+        return stdx::nullopt;
     }
-    return std::make_optional(static_cast<T>(*u));
+    return stdx::make_optional(static_cast<T>(*u));
 }
 
 char* encode_beatgrid(const std::vector<beatgrid_marker>& beatgrid, char* ptr)
@@ -184,8 +183,8 @@ beat_data beat_data::decode(const std::vector<char>& compressed_data)
     sampling_info sampling;
     std::tie(sampling.sample_rate, ptr) = decode_double_be(ptr);
     std::tie(sampling.sample_count, ptr) = decode_double_be(ptr);
-    result.sampling = sampling.sample_rate != 0
-        ? std::make_optional(sampling) : std::nullopt;
+    result.sampling = sampling.sample_rate != 0 ? stdx::make_optional(sampling)
+                                                : stdx::nullopt;
 
     uint8_t is_beat_data_set;
     std::tie(is_beat_data_set, ptr) = decode_uint8(ptr);
@@ -333,7 +332,7 @@ std::vector<char> loops_data::encode() const
 {
     auto total_label_length = std::accumulate(
         loops.begin(), loops.end(), int64_t{0},
-        [](int64_t x, const std::optional<loop>& loop) {
+        [](int64_t x, const stdx::optional<loop>& loop) {
             return x + (loop ? loop->label.length() : 0);
         });
 
@@ -565,7 +564,7 @@ std::vector<char> quick_cues_data::encode() const
 {
     auto total_label_length = std::accumulate(
         hot_cues.begin(), hot_cues.end(), int64_t{0},
-        [](int64_t x, const std::optional<hot_cue>& hot_cue) {
+        [](int64_t x, const stdx::optional<hot_cue>& hot_cue) {
             return x + (hot_cue ? hot_cue->label.length() : 0);
         });
 
@@ -743,8 +742,8 @@ track_data track_data::decode(const std::vector<char>& compressed_track_data)
     sampling_info sampling;
     std::tie(sampling.sample_rate, ptr) = decode_double_be(ptr);
     std::tie(sampling.sample_count, ptr) = decode_int64_be(ptr);
-    result.sampling = sampling.sample_rate != 0
-        ? std::make_optional(sampling) : std::nullopt;
+    result.sampling = sampling.sample_rate != 0 ? stdx::make_optional(sampling)
+                                                : stdx::nullopt;
 
     double raw_average_loudness;
     std::tie(raw_average_loudness, ptr) = decode_double_be(ptr);

--- a/src/djinterop/enginelibrary/performance_data_format.hpp
+++ b/src/djinterop/enginelibrary/performance_data_format.hpp
@@ -19,9 +19,9 @@
 
 #include <array>
 #include <cstdint>
-#include <optional>
 #include <vector>
 
+#include <djinterop/optional.hpp>
 #include <djinterop/performance_data.hpp>
 
 namespace djinterop
@@ -32,7 +32,7 @@ namespace enginelibrary
 {
 struct beat_data
 {
-    std::optional<sampling_info> sampling;
+    stdx::optional<sampling_info> sampling;
     std::vector<beatgrid_marker> default_beatgrid;
     std::vector<beatgrid_marker> adjusted_beatgrid;
 
@@ -72,7 +72,7 @@ struct high_res_waveform_data
 
 struct loops_data
 {
-    std::array<std::optional<loop>, 8> loops;  // Don't use curly braces here!
+    std::array<stdx::optional<loop>, 8> loops;  // Don't use curly braces here!
 
     loops_data() noexcept = default;
 
@@ -109,7 +109,7 @@ struct overview_waveform_data
 
 struct quick_cues_data
 {
-    std::array<std::optional<hot_cue>, 8> hot_cues;
+    std::array<stdx::optional<hot_cue>, 8> hot_cues;
     double adjusted_main_cue = 0;
     double default_main_cue = 0;
 
@@ -129,9 +129,9 @@ struct quick_cues_data
 
 struct track_data
 {
-    std::optional<sampling_info> sampling;
-    std::optional<double> average_loudness;  // range (0, 1]
-    std::optional<musical_key> key;
+    stdx::optional<sampling_info> sampling;
+    stdx::optional<double> average_loudness;  // range (0, 1]
+    stdx::optional<musical_key> key;
 
     track_data() noexcept = default;
 

--- a/src/djinterop/impl/crate_impl.hpp
+++ b/src/djinterop/impl/crate_impl.hpp
@@ -17,12 +17,12 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 #include <vector>
 
 #include <djinterop/crate.hpp>
 #include <djinterop/impl/database_impl.hpp>
+#include <djinterop/optional.hpp>
 #include <djinterop/track.hpp>
 
 namespace djinterop
@@ -47,12 +47,12 @@ public:
     virtual std::vector<crate> descendants() = 0;
     virtual bool is_valid() = 0;
     virtual std::string name() = 0;
-    virtual std::optional<crate> parent() = 0;
+    virtual stdx::optional<crate> parent() = 0;
     virtual void remove_track(track tr) = 0;
-    virtual std::optional<crate> sub_crate_by_name(
+    virtual stdx::optional<crate> sub_crate_by_name(
         const std::string& name) = 0;
     virtual void set_name(std::string name) = 0;
-    virtual void set_parent(std::optional<crate> parent) = 0;
+    virtual void set_parent(stdx::optional<crate> parent) = 0;
     virtual std::vector<track> tracks() = 0;
 
 private:

--- a/src/djinterop/impl/database_impl.hpp
+++ b/src/djinterop/impl/database_impl.hpp
@@ -17,9 +17,10 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
 #include <vector>
+
+#include <djinterop/optional.hpp>
 
 namespace djinterop
 {
@@ -34,7 +35,7 @@ public:
     virtual ~database_impl();
 
     virtual transaction_guard begin_transaction() = 0;
-    virtual std::optional<crate> crate_by_id(int64_t id) = 0;
+    virtual stdx::optional<crate> crate_by_id(int64_t id) = 0;
     virtual std::vector<crate> crates() = 0;
     virtual std::vector<crate> crates_by_name(const std::string& name) = 0;
     virtual crate create_root_crate(std::string name) = 0;
@@ -45,9 +46,9 @@ public:
     virtual void remove_crate(crate cr) = 0;
     virtual void remove_track(track tr) = 0;
     virtual std::vector<crate> root_crates() = 0;
-    virtual std::optional<crate> root_crate_by_name(
+    virtual stdx::optional<crate> root_crate_by_name(
         const std::string& name) = 0;
-    virtual std::optional<track> track_by_id(int64_t id) = 0;
+    virtual stdx::optional<track> track_by_id(int64_t id) = 0;
     virtual std::vector<track> tracks() = 0;
     virtual std::vector<track> tracks_by_relative_path(
         const std::string& relative_path) = 0;

--- a/src/djinterop/impl/track_impl.hpp
+++ b/src/djinterop/impl/track_impl.hpp
@@ -18,10 +18,10 @@
 #pragma once
 
 #include <chrono>
-#include <optional>
 #include <string>
 #include <vector>
 
+#include <djinterop/optional.hpp>
 #include <djinterop/performance_data.hpp>
 
 namespace djinterop
@@ -44,23 +44,23 @@ public:
         std::vector<beatgrid_marker> beatgrid) = 0;
     virtual double adjusted_main_cue() = 0;
     virtual void set_adjusted_main_cue(double sample_offset) = 0;
-    virtual std::optional<std::string> album() = 0;
-    virtual void set_album(std::optional<std::string> album) = 0;
-    virtual std::optional<int64_t> album_art_id() = 0;
-    virtual void set_album_art_id(std::optional<int64_t> album_art_id) = 0;
-    virtual std::optional<std::string> artist() = 0;
-    virtual void set_artist(std::optional<std::string> artist) = 0;
-    virtual std::optional<double> average_loudness() = 0;
+    virtual stdx::optional<std::string> album() = 0;
+    virtual void set_album(stdx::optional<std::string> album) = 0;
+    virtual stdx::optional<int64_t> album_art_id() = 0;
+    virtual void set_album_art_id(stdx::optional<int64_t> album_art_id) = 0;
+    virtual stdx::optional<std::string> artist() = 0;
+    virtual void set_artist(stdx::optional<std::string> artist) = 0;
+    virtual stdx::optional<double> average_loudness() = 0;
     virtual void set_average_loudness(
-        std::optional<double> average_loudness) = 0;
-    virtual std::optional<int64_t> bitrate() = 0;
-    virtual void set_bitrate(std::optional<int64_t> bitrate) = 0;
-    virtual std::optional<double> bpm() = 0;
-    virtual void set_bpm(std::optional<double> bpm) = 0;
-    virtual std::optional<std::string> comment() = 0;
-    virtual void set_comment(std::optional<std::string> comment) = 0;
-    virtual std::optional<std::string> composer() = 0;
-    virtual void set_composer(std::optional<std::string> composer) = 0;
+        stdx::optional<double> average_loudness) = 0;
+    virtual stdx::optional<int64_t> bitrate() = 0;
+    virtual void set_bitrate(stdx::optional<int64_t> bitrate) = 0;
+    virtual stdx::optional<double> bpm() = 0;
+    virtual void set_bpm(stdx::optional<double> bpm) = 0;
+    virtual stdx::optional<std::string> comment() = 0;
+    virtual void set_comment(stdx::optional<std::string> comment) = 0;
+    virtual stdx::optional<std::string> composer() = 0;
+    virtual void set_composer(stdx::optional<std::string> composer) = 0;
     virtual std::vector<crate> containing_crates() = 0;
     virtual database db() = 0;
     virtual std::vector<beatgrid_marker> default_beatgrid() = 0;
@@ -68,56 +68,55 @@ public:
         std::vector<beatgrid_marker> beatgrid) = 0;
     virtual double default_main_cue() = 0;
     virtual void set_default_main_cue(double sample_offset) = 0;
-    virtual std::optional<std::chrono::milliseconds> duration() = 0;
+    virtual stdx::optional<std::chrono::milliseconds> duration() = 0;
     virtual std::string file_extension() = 0;
     virtual std::string filename() = 0;
-    virtual std::optional<std::string> genre() = 0;
-    virtual void set_genre(std::optional<std::string> genre) = 0;
-    virtual std::optional<hot_cue> hot_cue_at(int32_t index) = 0;
-    virtual void set_hot_cue_at(
-        int32_t index, std::optional<hot_cue> cue) = 0;
-    virtual std::array<std::optional<hot_cue>, 8> hot_cues() = 0;
-    virtual void set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) = 0;
-    virtual std::optional<track_import_info> import_info() = 0;
+    virtual stdx::optional<std::string> genre() = 0;
+    virtual void set_genre(stdx::optional<std::string> genre) = 0;
+    virtual stdx::optional<hot_cue> hot_cue_at(int32_t index) = 0;
+    virtual void set_hot_cue_at(int32_t index, stdx::optional<hot_cue> cue) = 0;
+    virtual std::array<stdx::optional<hot_cue>, 8> hot_cues() = 0;
+    virtual void set_hot_cues(std::array<stdx::optional<hot_cue>, 8> cues) = 0;
+    virtual stdx::optional<track_import_info> import_info() = 0;
     virtual void set_import_info(
-        const std::optional<track_import_info>& import_info) = 0;
+        const stdx::optional<track_import_info>& import_info) = 0;
     virtual bool is_valid() = 0;
-    virtual std::optional<musical_key> key() = 0;
-    virtual void set_key(std::optional<musical_key> key) = 0;
-    virtual std::optional<std::chrono::system_clock::time_point>
+    virtual stdx::optional<musical_key> key() = 0;
+    virtual void set_key(stdx::optional<musical_key> key) = 0;
+    virtual stdx::optional<std::chrono::system_clock::time_point>
     last_accessed_at() = 0;
     virtual void set_last_accessed_at(
-        std::optional<std::chrono::system_clock::time_point>
+        stdx::optional<std::chrono::system_clock::time_point>
             last_accessed_at) = 0;
-    virtual std::optional<std::chrono::system_clock::time_point>
+    virtual stdx::optional<std::chrono::system_clock::time_point>
     last_modified_at() = 0;
     virtual void set_last_modified_at(
-        std::optional<std::chrono::system_clock::time_point>
+        stdx::optional<std::chrono::system_clock::time_point>
             last_modified_at) = 0;
-    virtual std::optional<std::chrono::system_clock::time_point>
+    virtual stdx::optional<std::chrono::system_clock::time_point>
     last_played_at() = 0;
     virtual void set_last_played_at(
-        std::optional<std::chrono::system_clock::time_point> time) = 0;
-    virtual std::optional<loop> loop_at(int32_t index) = 0;
-    virtual void set_loop_at(int32_t index, std::optional<loop> l) = 0;
-    virtual std::array<std::optional<loop>, 8> loops() = 0;
-    virtual void set_loops(std::array<std::optional<loop>, 8> loops) = 0;
+        stdx::optional<std::chrono::system_clock::time_point> time) = 0;
+    virtual stdx::optional<loop> loop_at(int32_t index) = 0;
+    virtual void set_loop_at(int32_t index, stdx::optional<loop> l) = 0;
+    virtual std::array<stdx::optional<loop>, 8> loops() = 0;
+    virtual void set_loops(std::array<stdx::optional<loop>, 8> loops) = 0;
     virtual std::vector<waveform_entry> overview_waveform() = 0;
-    virtual std::optional<std::string> publisher() = 0;
-    virtual void set_publisher(std::optional<std::string> publisher) = 0;
+    virtual stdx::optional<std::string> publisher() = 0;
+    virtual void set_publisher(stdx::optional<std::string> publisher) = 0;
     virtual int64_t required_waveform_samples_per_entry() = 0;
     virtual std::string relative_path() = 0;
     virtual void set_relative_path(std::string relative_path) = 0;
-    virtual std::optional<sampling_info> sampling() = 0;
-    virtual void set_sampling(std::optional<sampling_info> sample_rate) = 0;
-    virtual std::optional<std::string> title() = 0;
-    virtual void set_title(std::optional<std::string> title) = 0;
-    virtual std::optional<int32_t> track_number() = 0;
-    virtual void set_track_number(std::optional<int32_t> track_number) = 0;
+    virtual stdx::optional<sampling_info> sampling() = 0;
+    virtual void set_sampling(stdx::optional<sampling_info> sample_rate) = 0;
+    virtual stdx::optional<std::string> title() = 0;
+    virtual void set_title(stdx::optional<std::string> title) = 0;
+    virtual stdx::optional<int32_t> track_number() = 0;
+    virtual void set_track_number(stdx::optional<int32_t> track_number) = 0;
     virtual std::vector<waveform_entry> waveform() = 0;
     virtual void set_waveform(std::vector<waveform_entry> waveform) = 0;
-    virtual std::optional<int32_t> year() = 0;
-    virtual void set_year(std::optional<int32_t> year) = 0;
+    virtual stdx::optional<int32_t> year() = 0;
+    virtual void set_year(stdx::optional<int32_t> year) = 0;
 
 private:
     int64_t id_;

--- a/src/djinterop/impl/util.cpp
+++ b/src/djinterop/impl/util.cpp
@@ -18,14 +18,14 @@
 #include <djinterop/impl/util.hpp>
 
 #include <ios>
-#include <optional>
 #include <random>
 #include <sstream>
 #include <string>
 
+#include <djinterop/optional.hpp>
+
 namespace djinterop
 {
-
 std::string get_filename(const std::string& file_path)
 {
     // TODO (haslersn): How to handle Windows path separator?
@@ -33,10 +33,10 @@ std::string get_filename(const std::string& file_path)
     return file_path.substr(slash_pos + 1);
 }
 
-std::optional<std::string> get_file_extension(const std::string& file_path)
+stdx::optional<std::string> get_file_extension(const std::string& file_path)
 {
     auto filename = get_filename(file_path);
-    std::optional<std::string> file_extension;
+    stdx::optional<std::string> file_extension;
     auto dot_pos = filename.rfind('.');
     if (dot_pos != std::string::npos)
     {
@@ -54,43 +54,24 @@ std::string generate_random_uuid()
 
     // Generate a version 4 (random), variant 1 UUID.
     std::stringstream ss;
-    ss
-        << std::hex
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << "-"
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << "-4" // Version 4 indicator
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << "-"
-        << variant_nibble_dist(generator) // Variant 1 indicator
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << "-"
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator)
-        << nibble_dist(generator);
+    ss << std::hex << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator) << "-"
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << "-4"  // Version 4 indicator
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << "-"
+       << variant_nibble_dist(generator)  // Variant 1 indicator
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << "-" << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator) << nibble_dist(generator)
+       << nibble_dist(generator);
     return ss.str();
 }
 

--- a/src/djinterop/impl/util.hpp
+++ b/src/djinterop/impl/util.hpp
@@ -17,13 +17,14 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
+
+#include <djinterop/optional.hpp>
 
 namespace djinterop
 {
 std::string get_filename(const std::string& file_path);
-std::optional<std::string> get_file_extension(const std::string& file_path);
+stdx::optional<std::string> get_file_extension(const std::string& file_path);
 std::string generate_random_uuid();
 
 }  // namespace djinterop

--- a/src/djinterop/track.cpp
+++ b/src/djinterop/track.cpp
@@ -59,124 +59,124 @@ void track::set_adjusted_main_cue(double sample_offset) const
     pimpl_->set_adjusted_main_cue(sample_offset);
 }
 
-std::optional<std::string> track::album() const
+stdx::optional<std::string> track::album() const
 {
     return pimpl_->album();
 }
 
-void track::set_album(std::optional<std::string> album) const
+void track::set_album(stdx::optional<std::string> album) const
 {
     pimpl_->set_album(album);
 }
 
 void track::set_album(std::string album) const
 {
-    set_album(std::make_optional(album));
+    set_album(stdx::make_optional(album));
 }
 
-std::optional<int64_t> track::album_art_id() const
+stdx::optional<int64_t> track::album_art_id() const
 {
     return pimpl_->album_art_id();
 }
 
-void track::set_album_art_id(std::optional<int64_t> album_art_id) const
+void track::set_album_art_id(stdx::optional<int64_t> album_art_id) const
 {
     pimpl_->set_album_art_id(album_art_id);
 }
 
 void track::set_album_art_id(int64_t album_art_id) const
 {
-    set_album_art_id(std::make_optional(album_art_id));
+    set_album_art_id(stdx::make_optional(album_art_id));
 }
 
-std::optional<std::string> track::artist() const
+stdx::optional<std::string> track::artist() const
 {
     return pimpl_->artist();
 }
 
-void track::set_artist(std::optional<std::string> artist) const
+void track::set_artist(stdx::optional<std::string> artist) const
 {
     pimpl_->set_artist(artist);
 }
 
 void track::set_artist(std::string artist) const
 {
-    set_artist(std::make_optional(artist));
+    set_artist(stdx::make_optional(artist));
 }
 
-std::optional<double> track::average_loudness() const
+stdx::optional<double> track::average_loudness() const
 {
     return pimpl_->average_loudness();
 }
 
-void track::set_average_loudness(std::optional<double> average_loudness) const
+void track::set_average_loudness(stdx::optional<double> average_loudness) const
 {
     pimpl_->set_average_loudness(average_loudness);
 }
 
 void track::set_average_loudness(double average_loudness) const
 {
-    set_average_loudness(std::make_optional(average_loudness));
+    set_average_loudness(stdx::make_optional(average_loudness));
 }
 
-std::optional<int64_t> track::bitrate() const
+stdx::optional<int64_t> track::bitrate() const
 {
     return pimpl_->bitrate();
 }
 
-void track::set_bitrate(std::optional<int64_t> bitrate) const
+void track::set_bitrate(stdx::optional<int64_t> bitrate) const
 {
     pimpl_->set_bitrate(bitrate);
 }
 
 void track::set_bitrate(int64_t bitrate) const
 {
-    set_bitrate(std::make_optional(bitrate));
+    set_bitrate(stdx::make_optional(bitrate));
 }
 
-std::optional<double> track::bpm() const
+stdx::optional<double> track::bpm() const
 {
     return pimpl_->bpm();
 }
 
-void track::set_bpm(std::optional<double> bpm) const
+void track::set_bpm(stdx::optional<double> bpm) const
 {
     pimpl_->set_bpm(bpm);
 }
 
 void track::set_bpm(double bpm) const
 {
-    set_bpm(std::make_optional(bpm));
+    set_bpm(stdx::make_optional(bpm));
 }
 
-std::optional<std::string> track::comment() const
+stdx::optional<std::string> track::comment() const
 {
     return pimpl_->comment();
 }
 
-void track::set_comment(std::optional<std::string> comment) const
+void track::set_comment(stdx::optional<std::string> comment) const
 {
     pimpl_->set_comment(comment);
 }
 
 void track::set_comment(std::string comment) const
 {
-    set_comment(std::make_optional(comment));
+    set_comment(stdx::make_optional(comment));
 }
 
-std::optional<std::string> track::composer() const
+stdx::optional<std::string> track::composer() const
 {
     return pimpl_->composer();
 }
 
-void track::set_composer(std::optional<std::string> composer) const
+void track::set_composer(stdx::optional<std::string> composer) const
 {
     pimpl_->set_composer(composer);
 }
 
 void track::set_composer(std::string composer) const
 {
-    set_composer(std::make_optional(composer));
+    set_composer(stdx::make_optional(composer));
 }
 
 std::vector<crate> track::containing_crates() const
@@ -209,7 +209,7 @@ void track::set_default_main_cue(double sample_offset) const
     pimpl_->set_default_main_cue(sample_offset);
 }
 
-std::optional<milliseconds> track::duration() const
+stdx::optional<milliseconds> track::duration() const
 {
     return pimpl_->duration();
 }
@@ -224,42 +224,42 @@ std::string track::filename() const
     return pimpl_->filename();
 }
 
-std::optional<std::string> track::genre() const
+stdx::optional<std::string> track::genre() const
 {
     return pimpl_->genre();
 }
 
-void track::set_genre(std::optional<std::string> genre) const
+void track::set_genre(stdx::optional<std::string> genre) const
 {
     pimpl_->set_genre(genre);
 }
 
 void track::set_genre(std::string genre) const
 {
-    set_genre(std::make_optional(genre));
+    set_genre(stdx::make_optional(genre));
 }
 
-std::optional<hot_cue> track::hot_cue_at(int32_t index) const
+stdx::optional<hot_cue> track::hot_cue_at(int32_t index) const
 {
     return pimpl_->hot_cue_at(index);
 }
 
-void track::set_hot_cue_at(int32_t index, std::optional<hot_cue> cue) const
+void track::set_hot_cue_at(int32_t index, stdx::optional<hot_cue> cue) const
 {
     pimpl_->set_hot_cue_at(index, cue);
 }
 
 void track::set_hot_cue_at(int32_t index, hot_cue cue) const
 {
-    set_hot_cue_at(index, std::make_optional(std::move(cue)));
+    set_hot_cue_at(index, stdx::make_optional(std::move(cue)));
 }
 
-std::array<std::optional<hot_cue>, 8> track::hot_cues() const
+std::array<stdx::optional<hot_cue>, 8> track::hot_cues() const
 {
     return pimpl_->hot_cues();
 }
 
-void track::set_hot_cues(std::array<std::optional<hot_cue>, 8> cues) const
+void track::set_hot_cues(std::array<stdx::optional<hot_cue>, 8> cues) const
 {
     pimpl_->set_hot_cues(std::move(cues));
 }
@@ -269,20 +269,20 @@ int64_t track::id() const
     return pimpl_->id();
 }
 
-std::optional<track_import_info> track::import_info() const
+stdx::optional<track_import_info> track::import_info() const
 {
     return pimpl_->import_info();
 }
 
 void track::set_import_info(
-    const std::optional<track_import_info>& import_info) const
+    const stdx::optional<track_import_info>& import_info) const
 {
     pimpl_->set_import_info(import_info);
 }
 
 void track::set_import_info(const track_import_info& import_info) const
 {
-    set_import_info(std::make_optional(import_info));
+    set_import_info(stdx::make_optional(import_info));
 }
 
 bool track::is_valid() const
@@ -290,90 +290,90 @@ bool track::is_valid() const
     return pimpl_->is_valid();
 }
 
-std::optional<musical_key> track::key() const
+stdx::optional<musical_key> track::key() const
 {
     return pimpl_->key();
 }
 
-void track::set_key(std::optional<musical_key> key) const
+void track::set_key(stdx::optional<musical_key> key) const
 {
     pimpl_->set_key(key);
 }
 
 void track::set_key(musical_key key) const
 {
-    set_key(std::make_optional(key));
+    set_key(stdx::make_optional(key));
 }
 
-std::optional<system_clock::time_point> track::last_accessed_at() const
+stdx::optional<system_clock::time_point> track::last_accessed_at() const
 {
     return pimpl_->last_accessed_at();
 }
 
 void track::set_last_accessed_at(
-    std::optional<system_clock::time_point> accessed_at) const
+    stdx::optional<system_clock::time_point> accessed_at) const
 {
     pimpl_->set_last_accessed_at(accessed_at);
 }
 
 void track::set_last_accessed_at(system_clock::time_point accessed_at) const
 {
-    set_last_accessed_at(std::make_optional(accessed_at));
+    set_last_accessed_at(stdx::make_optional(accessed_at));
 }
 
-std::optional<system_clock::time_point> track::last_modified_at() const
+stdx::optional<system_clock::time_point> track::last_modified_at() const
 {
     return pimpl_->last_modified_at();
 }
 
 void track::set_last_modified_at(
-    std::optional<system_clock::time_point> modified_at) const
+    stdx::optional<system_clock::time_point> modified_at) const
 {
     pimpl_->set_last_modified_at(modified_at);
 }
 
 void track::set_last_modified_at(system_clock::time_point modified_at) const
 {
-    set_last_modified_at(std::make_optional(modified_at));
+    set_last_modified_at(stdx::make_optional(modified_at));
 }
 
-std::optional<system_clock::time_point> track::last_played_at() const
+stdx::optional<system_clock::time_point> track::last_played_at() const
 {
     return pimpl_->last_played_at();
 }
 
 void track::set_last_played_at(
-    std::optional<system_clock::time_point> played_at) const
+    stdx::optional<system_clock::time_point> played_at) const
 {
     pimpl_->set_last_played_at(played_at);
 }
 
 void track::set_last_played_at(system_clock::time_point played_at) const
 {
-    set_last_played_at(std::make_optional(played_at));
+    set_last_played_at(stdx::make_optional(played_at));
 }
 
-std::optional<loop> track::loop_at(int32_t index) const
+stdx::optional<loop> track::loop_at(int32_t index) const
 {
     return pimpl_->loop_at(index);
 }
 
-void track::set_loop_at(int32_t index, std::optional<loop> l) const
+void track::set_loop_at(int32_t index, stdx::optional<loop> l) const
 {
     pimpl_->set_loop_at(index, l);
 }
 
 void track::set_loop_at(int32_t index, loop l) const
 {
-    set_loop_at(index, std::make_optional(l));
+    set_loop_at(index, stdx::make_optional(l));
 }
 
-std::array<std::optional<loop>, 8> track::loops() const
+std::array<stdx::optional<loop>, 8> track::loops() const
 {
     return pimpl_->loops();
 }
 
-void track::set_loops(std::array<std::optional<loop>, 8> loops) const
+void track::set_loops(std::array<stdx::optional<loop>, 8> loops) const
 {
     pimpl_->set_loops(std::move(loops));
 }
@@ -383,19 +383,19 @@ std::vector<waveform_entry> track::overview_waveform() const
     return pimpl_->overview_waveform();
 }
 
-std::optional<std::string> track::publisher() const
+stdx::optional<std::string> track::publisher() const
 {
     return pimpl_->publisher();
 }
 
-void track::set_publisher(std::optional<std::string> publisher) const
+void track::set_publisher(stdx::optional<std::string> publisher) const
 {
     pimpl_->set_publisher(publisher);
 }
 
 void track::set_publisher(std::string publisher) const
 {
-    set_publisher(std::make_optional(publisher));
+    set_publisher(stdx::make_optional(publisher));
 }
 
 int64_t track::required_waveform_samples_per_entry() const
@@ -413,49 +413,49 @@ void track::set_relative_path(std::string relative_path) const
     pimpl_->set_relative_path(relative_path);
 }
 
-std::optional<sampling_info> track::sampling() const
+stdx::optional<sampling_info> track::sampling() const
 {
     return pimpl_->sampling();
 }
 
-void track::set_sampling(std::optional<sampling_info> sampling) const
+void track::set_sampling(stdx::optional<sampling_info> sampling) const
 {
     pimpl_->set_sampling(sampling);
 }
 
 void track::set_sampling(sampling_info sampling) const
 {
-    set_sampling(std::make_optional(sampling));
+    set_sampling(stdx::make_optional(sampling));
 }
 
-std::optional<std::string> track::title() const
+stdx::optional<std::string> track::title() const
 {
     return pimpl_->title();
 }
 
-void track::set_title(std::optional<std::string> title) const
+void track::set_title(stdx::optional<std::string> title) const
 {
     pimpl_->set_title(title);
 }
 
 void track::set_title(std::string title) const
 {
-    set_title(std::make_optional(title));
+    set_title(stdx::make_optional(title));
 }
 
-std::optional<int32_t> track::track_number() const
+stdx::optional<int32_t> track::track_number() const
 {
     return pimpl_->track_number();
 }
 
-void track::set_track_number(std::optional<int32_t> track_number) const
+void track::set_track_number(stdx::optional<int32_t> track_number) const
 {
     pimpl_->set_track_number(track_number);
 }
 
 void track::set_track_number(int32_t track_number) const
 {
-    set_track_number(std::make_optional(track_number));
+    set_track_number(stdx::make_optional(track_number));
 }
 
 std::vector<waveform_entry> track::waveform() const
@@ -468,19 +468,19 @@ void track::set_waveform(std::vector<waveform_entry> waveform) const
     pimpl_->set_waveform(waveform);
 }
 
-std::optional<int32_t> track::year() const
+stdx::optional<int32_t> track::year() const
 {
     return pimpl_->year();
 }
 
-void track::set_year(std::optional<int32_t> year) const
+void track::set_year(stdx::optional<int32_t> year) const
 {
     pimpl_->set_year(year);
 }
 
 void track::set_year(int32_t year) const
 {
-    set_year(std::make_optional(year));
+    set_year(stdx::make_optional(year));
 }
 
 track::track(std::shared_ptr<track_impl> pimpl) : pimpl_{std::move(pimpl)} {}

--- a/test/enginelibrary/performance_data_test.cpp
+++ b/test/enginelibrary/performance_data_test.cpp
@@ -71,14 +71,14 @@ static void populate_track_1(djinterop::track& t)
     t.set_genre("Tech House"s);
     t.set_comment("Purchased at Beatport.com"s);
     t.set_publisher("Stereo Productions"s);
-    t.set_composer(std::nullopt);
+    t.set_composer(djinterop::stdx::nullopt);
     t.set_key(djinterop::musical_key::a_minor);
     t.set_relative_path("../01 - Dennis Cruz - Mad (Original Mix).mp3");
     t.set_last_modified_at(c::system_clock::time_point{c::seconds{1509371790}});
     t.set_bitrate(320);
-    t.set_last_played_at(std::nullopt);
+    t.set_last_played_at(djinterop::stdx::nullopt);
     t.set_last_accessed_at(c::system_clock::time_point{c::seconds{1509321600}});
-    t.set_import_info(std::nullopt);
+    t.set_import_info(djinterop::stdx::nullopt);
 
     // Track data fields
     t.set_sampling(djinterop::sampling_info{44100, 17452800});
@@ -99,29 +99,31 @@ static void populate_track_1(djinterop::track& t)
     t.set_default_main_cue(1144.012);
 
     // Loop fields
-    std::array<std::optional<djinterop::loop>, 8> loops;
-    loops[0] = djinterop::loop{"Loop 1", 1144.012, 345339.134,
-                               el::standard_pad_colors::pad_1};
-    loops[1] = djinterop::loop{"Loop 2", 2582607.427, 2754704.988,
-                               el::standard_pad_colors::pad_2};
-    loops[3] = djinterop::loop{"Loop 4", 4131485.476, 4303583.037,
-                               el::standard_pad_colors::pad_4};
+    std::array<djinterop::stdx::optional<djinterop::loop>, 8> loops;
+    loops[0] = djinterop::loop{
+        "Loop 1", 1144.012, 345339.134, el::standard_pad_colors::pad_1};
+    loops[1] = djinterop::loop{
+        "Loop 2", 2582607.427, 2754704.988, el::standard_pad_colors::pad_2};
+    loops[3] = djinterop::loop{
+        "Loop 4", 4131485.476, 4303583.037, el::standard_pad_colors::pad_4};
     t.set_loops(std::move(loops));
 
     // High-resolution waveform data
     std::vector<djinterop::waveform_entry> waveform;
     int64_t samples_per_entry = t.required_waveform_samples_per_entry();
-    int64_t waveform_size = (t.sampling()->sample_count + samples_per_entry - 1) / samples_per_entry;
+    int64_t waveform_size =
+        (t.sampling()->sample_count + samples_per_entry - 1) /
+        samples_per_entry;
     waveform.reserve(waveform_size);
     for (int64_t i = 0; i < waveform_size; ++i)
     {
-        waveform.push_back({
-                {(uint8_t)(i * 255 / waveform_size),
-                 (uint8_t)(i * 255 / waveform_size)},
-                {(uint8_t)(i * 127 / waveform_size),
-                 (uint8_t)(i * 127 / waveform_size)},
-                {(uint8_t)(i * 63 / waveform_size),
-                 (uint8_t)(i * 63 / waveform_size)}});
+        waveform.push_back(
+            {{(uint8_t)(i * 255 / waveform_size),
+              (uint8_t)(i * 255 / waveform_size)},
+             {(uint8_t)(i * 127 / waveform_size),
+              (uint8_t)(i * 127 / waveform_size)},
+             {(uint8_t)(i * 63 / waveform_size),
+              (uint8_t)(i * 63 / waveform_size)}});
     }
     t.set_waveform(std::move(waveform));
 }
@@ -238,7 +240,7 @@ static void populate_track_2(djinterop::track& t)
     t.set_last_played_at(c::system_clock::time_point{c::seconds{1518739200}});
     t.set_last_accessed_at(c::system_clock::time_point{c::seconds{1518815683}});
     t.set_import_info({"e535b170-26ef-4f30-8cb2-5b9fa4c2a27f", 123});
-    
+
     // Track data fields
     t.set_sampling(djinterop::sampling_info{48000, 10795393});
     t.set_key(djinterop::musical_key::b_minor);
@@ -249,7 +251,7 @@ static void populate_track_2(djinterop::track& t)
     t.set_adjusted_beatgrid({{-4, -107595.55}, {402, 10820254.92}});
 
     // Quick cue fields
-    std::array<std::optional<djinterop::hot_cue>, 8> cues;
+    std::array<djinterop::stdx::optional<djinterop::hot_cue>, 8> cues;
     cues[1] =
         djinterop::hot_cue{"Cue 2", 1234567.89, el::standard_pad_colors::pad_2};
     t.set_hot_cues(std::move(cues));
@@ -263,18 +265,20 @@ static void populate_track_2(djinterop::track& t)
 
     // High-resolution waveform data
     int64_t samples_per_entry = t.required_waveform_samples_per_entry();
-    int64_t waveform_size = (t.sampling()->sample_count + samples_per_entry - 1) / samples_per_entry;
+    int64_t waveform_size =
+        (t.sampling()->sample_count + samples_per_entry - 1) /
+        samples_per_entry;
     std::vector<djinterop::waveform_entry> waveform;
     waveform.reserve(waveform_size);
     for (int64_t i = 0; i < waveform_size; ++i)
     {
-        waveform.push_back({
-                {(uint8_t)(i * 255 / waveform_size),
-                 (uint8_t)(i * 255 / waveform_size)},
-                {(uint8_t)(i * 127 / waveform_size),
-                 (uint8_t)(i * 127 / waveform_size)},
-                {(uint8_t)(i * 63 / waveform_size),
-                 (uint8_t)(i * 63 / waveform_size)}});
+        waveform.push_back(
+            {{(uint8_t)(i * 255 / waveform_size),
+              (uint8_t)(i * 255 / waveform_size)},
+             {(uint8_t)(i * 127 / waveform_size),
+              (uint8_t)(i * 127 / waveform_size)},
+             {(uint8_t)(i * 63 / waveform_size),
+              (uint8_t)(i * 63 / waveform_size)}});
     }
     t.set_waveform(std::move(waveform));
 }
@@ -393,4 +397,3 @@ BOOST_AUTO_TEST_CASE(set_hot_cue_at__empty_track_valid_entries__succeeds)
     auto hot_cues = t.hot_cues();
     BOOST_CHECK(hot_cues[1]);
 }
-

--- a/test/enginelibrary/track_test.cpp
+++ b/test/enginelibrary/track_test.cpp
@@ -53,13 +53,13 @@ static fs::path create_temp_dir()
     return temp_dir;
 }
 
-static void remove_temp_dir(const fs::path &temp_dir)
+static void remove_temp_dir(const fs::path& temp_dir)
 {
     fs::remove_all(temp_dir);
     std::cout << "Removed temp dir at " << temp_dir.string() << std::endl;
 }
 
-static void populate_example_track_1(djinterop::track &t)
+static void populate_example_track_1(djinterop::track& t)
 {
     t.set_track_number(1);
     t.set_bpm(123);
@@ -70,18 +70,18 @@ static void populate_example_track_1(djinterop::track &t)
     t.set_genre("Tech House"s);
     t.set_comment("Purchased at Beatport.com"s);
     t.set_publisher("Stereo Productions"s);
-    t.set_composer(std::nullopt);
+    t.set_composer(djinterop::stdx::nullopt);
     t.set_key(djinterop::musical_key::a_minor);
     t.set_relative_path("../01 - Dennis Cruz - Mad (Original Mix).mp3");
     t.set_last_modified_at(c::system_clock::time_point{c::seconds{1509371790}});
     t.set_bitrate(320);
-    t.set_last_played_at(std::nullopt);
+    t.set_last_played_at(djinterop::stdx::nullopt);
     t.set_last_accessed_at(c::system_clock::time_point{c::seconds{1509321600}});
-    t.set_import_info(std::nullopt);
+    t.set_import_info(djinterop::stdx::nullopt);
     t.set_album_art_id(2);
 }
 
-static void check_track_1(djinterop::track &t)
+static void check_track_1(djinterop::track& t)
 {
     BOOST_CHECK(t.is_valid());
     BOOST_CHECK_EQUAL(*t.track_number(), 1);
@@ -114,7 +114,7 @@ static void check_track_1(djinterop::track &t)
     BOOST_CHECK_EQUAL(*t.album_art_id(), 2);
 }
 
-static void populate_example_track_2(djinterop::track &t)
+static void populate_example_track_2(djinterop::track& t)
 {
     t.set_track_number(3);
     t.set_bpm(128);
@@ -137,7 +137,7 @@ static void populate_example_track_2(djinterop::track &t)
     t.set_album_art_id(1);
 }
 
-static void check_track_2(djinterop::track &t)
+static void check_track_2(djinterop::track& t)
 {
     BOOST_CHECK(t.is_valid());
     BOOST_CHECK_EQUAL(*t.track_number(), 3);
@@ -312,4 +312,3 @@ BOOST_AUTO_TEST_CASE(op_copy_assign__saved_track__copied_fields)
     check_track_1(copy);
     remove_temp_dir(temp_dir);
 }
-


### PR DESCRIPTION
At build time, the library will now choose `std::optional<T>` or `std::experimental::optional<T>` (in order of preference), depending on which one is available.  A new alias `djinterop::stdx::optional` is available for clients to use.

Note that sqlite_modern_cpp performs its own detection of `std::optional<T>` or its experimental equivalent: in order for the library to build correctly, both will need to detect the same version of `std::optional<T>`.

Resolves #14 .