### PR TITLE
Fix exception when no average loudness set

### DIFF
--- a/src/djinterop/enginelibrary/el_track_impl.cpp
+++ b/src/djinterop/enginelibrary/el_track_impl.cpp
@@ -317,7 +317,11 @@ void el_track_impl::set_average_loudness(
 {
     el_transaction_guard_impl trans{storage_};
     auto track_d = get_track_data();
-    track_d.average_loudness = average_loudness;
+
+    // Zero average loudness is interpreted as no average loudness.
+    track_d.average_loudness =
+        average_loudness == 0 ? stdx::nullopt : average_loudness;
+
     set_track_data(track_d);
     trans.commit();
 }


### PR DESCRIPTION
If the average loudness in Engine Library format is zero, this is now interpreted as there being no average loudness.