### PR TITLE
Fix exception if zero sample rate provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The meson/ninja build should be preferred in all other cases.
 #
 cmake_minimum_required(VERSION 3.13)
-project(libdjinterop VERSION 0.14.3)
+project(libdjinterop VERSION 0.14.4)
 
 # Require C++17
 set(CMAKE_CXX_STANDARD 17)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'djinterop',
     'cpp', 'c',
-    version: '0.14.3',
+    version: '0.14.4',
     license: 'LGPL-3.0',
     default_options: ['cpp_std=c++17', 'default_library=shared'])
 

--- a/src/djinterop/enginelibrary/el_track_impl.cpp
+++ b/src/djinterop/enginelibrary/el_track_impl.cpp
@@ -723,8 +723,14 @@ void el_track_impl::set_sampling(stdx::optional<sampling_info> sampling)
 {
     el_transaction_guard_impl trans{storage_};
 
+    // A zero sample rate is interpreted as no sample rate.
+    if (sampling && sampling->sample_rate == 0)
+    {
+        sampling = stdx::nullopt;
+    }
+
     stdx::optional<int64_t> secs;
-    if (sampling)
+    if (sampling && sampling->sample_rate != 0)
     {
         secs = static_cast<int64_t>(
             sampling->sample_count / sampling->sample_rate);

--- a/test/enginelibrary/track_test.cpp
+++ b/test/enginelibrary/track_test.cpp
@@ -312,3 +312,31 @@ BOOST_AUTO_TEST_CASE(op_copy_assign__saved_track__copied_fields)
     check_track_1(copy);
     remove_temp_dir(temp_dir);
 }
+
+BOOST_AUTO_TEST_CASE(set_average_loudness__zero__no_loudness)
+{
+    // Arrange
+    auto temp_dir = create_temp_dir();
+    auto db = el::create_database(temp_dir.string(), el::version_1_7_1);
+    auto t = db.create_track("");
+
+    // Act
+    t.set_average_loudness(0);
+
+    // Assert
+    BOOST_CHECK(t.average_loudness() == djinterop::stdx::nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(set_sampling__zero_rate__no_sampling)
+{
+    // Arrange
+    auto temp_dir = create_temp_dir();
+    auto db = el::create_database(temp_dir.string(), el::version_1_7_1);
+    auto t = db.create_track("");
+
+    // Act
+    t.set_sampling(djinterop::sampling_info{});
+
+    // Assert
+    BOOST_CHECK(t.sampling() == djinterop::stdx::nullopt);
+}


### PR DESCRIPTION
Setting a zero sampling rate is interpreted as there being no sampling information.

Fixes #33 .