### PR TITLE
Bump version to 0.14.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The meson/ninja build should be preferred in all other cases.
 #
 cmake_minimum_required(VERSION 3.13)
-project(libdjinterop VERSION 0.14.4)
+project(libdjinterop VERSION 0.14.6)
 
 # Require C++17
 set(CMAKE_CXX_STANDARD 17)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'djinterop',
     'cpp', 'c',
-    version: '0.14.5',
+    version: '0.14.6',
     license: 'LGPL-3.0',
     default_options: ['cpp_std=c++17', 'default_library=shared'])
 


### PR DESCRIPTION
As requested here: https://github.com/xsco/libdjinterop/pull/40#issuecomment-757550855

Also fixes the inconsistent version in `CMakeLists.txt` and
`meson.build`.