### PR TITLE
Mark `ext` folder as `linguist-vendored`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ext/** linguist-vendored


### PR DESCRIPTION
This prevents vendored libraries from showing up in the repo's language statistics. Before:

![image](https://user-images.githubusercontent.com/30873659/171523038-3cbfff5c-6974-4e37-be3f-3af44fc43bae.png)

After:

![image](https://user-images.githubusercontent.com/30873659/171523015-ef374ab2-5d39-49af-8ef3-6c87b6b0f95e.png)
