### PR TITLE
Preserve extra data when encoding/decoding Engine blobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(libdjinterop
-        VERSION 0.19.1
+        VERSION 0.19.2
         DESCRIPTION "C++ library providing access to DJ record libraries")
 set(PROJECT_HOMEPAGE_URL "https://github.com/xsco/libdjinterop")
 

--- a/include/djinterop/config.hpp.in
+++ b/include/djinterop/config.hpp.in
@@ -61,4 +61,10 @@
 #cmakedefine DJINTEROP_STD_OPTIONAL
 #cmakedefine DJINTEROP_STD_EXPERIMENTAL_OPTIONAL
 
+#include <cstddef>
+static_assert(sizeof(std::byte) == 1,
+              "Only platforms where sizeof(std::byte) == 1 are supported");
+static_assert(alignof(std::byte) == 1,
+              "Only platforms where alignof(std::byte) == 1 are supported");
+
 #endif  // DJINTEROP_CONFIG_HPP

--- a/include/djinterop/engine/v2/beat_data_blob.hpp
+++ b/include/djinterop/engine/v2/beat_data_blob.hpp
@@ -21,6 +21,7 @@
 #error This library needs at least a C++17 compliant compiler
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <ostream>
 #include <string>
@@ -106,17 +107,20 @@ struct DJINTEROP_PUBLIC beat_data_blob
     /// List of markers making up the adjusted beat grid.
     beat_grid_marker_blobs_type adjusted_beat_grid;
 
+    /// Extra data (if any) found in a decoded blob.
+    std::vector<std::byte> extra_data;
+
     /// Encode this struct into binary blob form.
     ///
     /// \return Returns a byte array.
-    [[nodiscard]] std::vector<char> to_blob() const;
+    [[nodiscard]] std::vector<std::byte> to_blob() const;
 
     /// Decode an instance of this struct from binary blob form.
     ///
     /// \param blob Binary blob.
     /// \return Returns a decoded instance of this struct.
     [[nodiscard]] static beat_data_blob from_blob(
-        const std::vector<char>& blob);
+        const std::vector<std::byte>& blob);
 
     friend bool operator==(
         const beat_data_blob& lhs, const beat_data_blob& rhs) noexcept
@@ -125,7 +129,8 @@ struct DJINTEROP_PUBLIC beat_data_blob
                lhs.samples == rhs.samples &&
                lhs.is_beatgrid_set == rhs.is_beatgrid_set &&
                lhs.default_beat_grid == rhs.default_beat_grid &&
-               lhs.adjusted_beat_grid == rhs.adjusted_beat_grid;
+               lhs.adjusted_beat_grid == rhs.adjusted_beat_grid &&
+               lhs.extra_data == rhs.extra_data;
     }
 
     friend bool operator!=(

--- a/include/djinterop/engine/v2/loops_blob.hpp
+++ b/include/djinterop/engine/v2/loops_blob.hpp
@@ -21,6 +21,7 @@
 #error This library needs at least a C++17 compliant compiler
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <ostream>
 #include <string>
@@ -98,21 +99,25 @@ struct DJINTEROP_PUBLIC loops_blob
     /// List of loops.
     std::vector<loop_blob> loops;
 
+    /// Extra data (if any) found in a decoded blob.
+    std::vector<std::byte> extra_data;
+
     /// Encode this struct into binary blob form.
     ///
     /// \return Returns a byte array.
-    [[nodiscard]] std::vector<char> to_blob() const;
+    [[nodiscard]] std::vector<std::byte> to_blob() const;
 
     /// Decode an instance of this struct from binary blob form.
     ///
     /// \param blob Binary blob.
     /// \return Returns a decoded instance of this struct.
-    [[nodiscard]] static loops_blob from_blob(const std::vector<char>& blob);
+    [[nodiscard]] static loops_blob from_blob(
+        const std::vector<std::byte>& blob);
 
     friend bool operator==(
         const loops_blob& lhs, const loops_blob& rhs) noexcept
     {
-        return lhs.loops == rhs.loops;
+        return lhs.loops == rhs.loops && lhs.extra_data == rhs.extra_data;
     }
 
     friend bool operator!=(

--- a/include/djinterop/engine/v2/overview_waveform_data_blob.hpp
+++ b/include/djinterop/engine/v2/overview_waveform_data_blob.hpp
@@ -21,6 +21,7 @@
 #error This library needs at least a C++17 compliant compiler
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <ostream>
 #include <vector>
@@ -79,17 +80,20 @@ struct DJINTEROP_PUBLIC overview_waveform_data_blob
     /// Maximum values across all waveform points.
     overview_waveform_point maximum_point;
 
+    /// Extra data (if any) found in a decoded blob.
+    std::vector<std::byte> extra_data;
+
     /// Encode this struct into binary blob form.
     ///
     /// \return Returns a byte array.
-    [[nodiscard]] std::vector<char> to_blob() const;
+    [[nodiscard]] std::vector<std::byte> to_blob() const;
 
     /// Decode an instance of this struct from binary blob form.
     ///
     /// \param blob Binary blob.
     /// \return Returns a decoded instance of this struct.
     [[nodiscard]] static overview_waveform_data_blob from_blob(
-        const std::vector<char>& blob);
+        const std::vector<std::byte>& blob);
 
     friend bool operator==(
         const overview_waveform_data_blob& lhs,
@@ -98,7 +102,8 @@ struct DJINTEROP_PUBLIC overview_waveform_data_blob
         return lhs.samples_per_waveform_point ==
                    rhs.samples_per_waveform_point &&
                lhs.waveform_points == rhs.waveform_points &&
-               lhs.maximum_point == rhs.maximum_point;
+               lhs.maximum_point == rhs.maximum_point &&
+               lhs.extra_data == rhs.extra_data;
     }
 
     friend bool operator!=(

--- a/include/djinterop/engine/v2/overview_waveform_data_blob.hpp
+++ b/include/djinterop/engine/v2/overview_waveform_data_blob.hpp
@@ -61,9 +61,10 @@ struct DJINTEROP_PUBLIC overview_waveform_point
     friend std::ostream& operator<<(
         std::ostream& os, const overview_waveform_point& obj) noexcept
     {
-        os << "overview_waveform_point{low_value=" << obj.low_value
-           << ", mid_value=" << obj.mid_value
-           << ", high_value=" << obj.high_value << "}";
+        os << "overview_waveform_point{low_value="
+           << static_cast<int>(obj.low_value)
+           << ", mid_value=" << static_cast<int>(obj.mid_value)
+           << ", high_value=" << static_cast<int>(obj.high_value) << "}";
         return os;
     }
 };

--- a/include/djinterop/engine/v2/quick_cues_blob.hpp
+++ b/include/djinterop/engine/v2/quick_cues_blob.hpp
@@ -21,6 +21,7 @@
 #error This library needs at least a C++17 compliant compiler
 #endif
 
+#include <cstddef>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -105,17 +106,20 @@ struct DJINTEROP_PUBLIC quick_cues_blob
     /// Default cue point.
     double default_main_cue;
 
+    /// Extra data (if any) found in a decoded blob.
+    std::vector<std::byte> extra_data;
+
     /// Encode this struct into binary blob form.
     ///
     /// \return Returns a byte array.
-    [[nodiscard]] std::vector<char> to_blob() const;
+    [[nodiscard]] std::vector<std::byte> to_blob() const;
 
     /// Decode an instance of this struct from binary blob form.
     ///
     /// \param blob Binary blob.
     /// \return Returns a decoded instance of this struct.
     [[nodiscard]] static quick_cues_blob from_blob(
-        const std::vector<char>& blob);
+        const std::vector<std::byte>& blob);
 
     friend bool operator==(
         const quick_cues_blob& lhs, const quick_cues_blob& rhs) noexcept
@@ -123,7 +127,8 @@ struct DJINTEROP_PUBLIC quick_cues_blob
         return lhs.quick_cues == rhs.quick_cues &&
                lhs.adjusted_main_cue == rhs.adjusted_main_cue &&
                lhs.is_main_cue_adjusted == rhs.is_main_cue_adjusted &&
-               lhs.default_main_cue == rhs.default_main_cue;
+               lhs.default_main_cue == rhs.default_main_cue &&
+               lhs.extra_data == rhs.extra_data;
     }
 
     friend bool operator!=(

--- a/include/djinterop/engine/v2/track_data_blob.hpp
+++ b/include/djinterop/engine/v2/track_data_blob.hpp
@@ -21,6 +21,7 @@
 #error This library needs at least a C++17 compliant compiler
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <ostream>
 #include <vector>
@@ -38,31 +39,43 @@ struct DJINTEROP_PUBLIC track_data_blob
     /// Number of samples in the track.
     int64_t samples;
 
-    /// Number (possibly?) indicating average loudness.
-    double average_loudness;
-
     /// Musical key.
     int32_t key;
+
+    /// Number (possibly?) indicating average loudness.
+    double average_loudness_1;
+
+    /// Number (possibly?) indicating average loudness.
+    double average_loudness_2;
+
+    /// Number (possibly?) indicating average loudness.
+    double average_loudness_3;
+
+    /// Extra data (if any) found in a decoded blob.
+    std::vector<std::byte> extra_data;
 
     /// Encode this struct into binary blob form.
     ///
     /// \return Returns a byte array.
-    [[nodiscard]] std::vector<char> to_blob() const;
+    [[nodiscard]] std::vector<std::byte> to_blob() const;
 
     /// Decode an instance of this struct from binary blob form.
     ///
     /// \param blob Binary blob.
     /// \return Returns a decoded instance of this struct.
     [[nodiscard]] static track_data_blob from_blob(
-        const std::vector<char>& blob);
+        const std::vector<std::byte>& blob);
 
     friend bool operator==(
         const track_data_blob& lhs, const track_data_blob& rhs) noexcept
     {
         return lhs.sample_rate == rhs.sample_rate &&
                lhs.samples == rhs.samples &&
-               lhs.average_loudness == rhs.average_loudness &&
-               lhs.key == rhs.key;
+               lhs.key == rhs.key &&
+               lhs.average_loudness_1 == rhs.average_loudness_1 &&
+               lhs.average_loudness_2 == rhs.average_loudness_2 &&
+               lhs.average_loudness_3 == rhs.average_loudness_3 &&
+               lhs.extra_data == rhs.extra_data;
     }
 
     friend bool operator!=(
@@ -76,8 +89,11 @@ struct DJINTEROP_PUBLIC track_data_blob
     {
         os << "track_data_blob{sample_rate=" << obj.sample_rate
            << ", samples=" << obj.samples
-           << ", average_loudness=" << obj.average_loudness
-           << ", key=" << obj.key << "}";
+           << ", key=" << obj.key
+           << ", average_loudness_1=" << obj.average_loudness_1
+           << ", average_loudness_2=" << obj.average_loudness_2
+           << ", average_loudness_3=" << obj.average_loudness_3
+           << "}";
         return os;
     }
 };

--- a/include/djinterop/pad_color.hpp
+++ b/include/djinterop/pad_color.hpp
@@ -78,7 +78,7 @@ inline bool operator!=(const pad_color& x, const pad_color& y)
 inline std::ostream& operator<<(std::ostream& o, const djinterop::pad_color& v)
 {
     o << "pad_color{r=" << (int)v.r << ", g=" << (int)v.g << ", b=" << (int)v.b
-      << ", a=" << (int)v.a;
+      << ", a=" << (int)v.a << "}";
     return o;
 }
 }  // namespace djinterop

--- a/src/djinterop/engine/encode_decode_utils.cpp
+++ b/src/djinterop/engine/encode_decode_utils.cpp
@@ -15,28 +15,31 @@
     along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <zlib.h>
 #include <algorithm>
+#include <cstddef>
 #include <stdexcept>
 #include <system_error>
 #include <vector>
+
+#include <zlib.h>
 
 #include "encode_decode_utils.hpp"
 
 namespace djinterop::engine
 {
 // Uncompress a zlib'ed BLOB
-std::vector<char> zlib_uncompress(
-    const std::vector<char>& compressed, std::vector<char> uncompressed)
+std::vector<std::byte> zlib_uncompress(
+    const std::vector<std::byte>& compressed,
+    std::vector<std::byte> uncompressed)
 {
-    if (compressed.size() > 0 && compressed.size() < 4)
+    if (!compressed.empty() && compressed.size() < 4)
         throw std::length_error(
             "Compressed data is less than the minimum size of 4 bytes");
 
     uncompressed.clear();
 
     auto apparent_size =
-        compressed.size() == 0 ? 0 : decode_int32_be(compressed.data()).first;
+        compressed.empty() ? 0 : decode_int32_be(compressed.data()).first;
 
     if (apparent_size == 0)
     {
@@ -46,12 +49,12 @@ std::vector<char> zlib_uncompress(
 
     uncompressed.reserve(apparent_size);
 
-    const char* ptr = &compressed[4];
-    const char* end = ptr + compressed.size();
+    auto* ptr = &compressed[4];
+    auto* end = ptr + compressed.size();
     const int chunk_size = 16384;
     int ret;
     unsigned int have;
-    unsigned char out[chunk_size];
+    std::byte out[chunk_size];
 
     z_stream strm;
     strm.zalloc = Z_NULL;
@@ -62,8 +65,8 @@ std::vector<char> zlib_uncompress(
 
     ret = inflateInit(&strm);
     if (ret != Z_OK)
-        throw std::system_error{ret, std::system_category(),
-                                "Error calling inflateInit from zlib"};
+        throw std::system_error{
+            ret, std::system_category(), "Error calling inflateInit from zlib"};
 
     // Take chunks from the input vector
     do
@@ -75,7 +78,7 @@ std::vector<char> zlib_uncompress(
         // Run inflate() on until we are no longer filling the output buffer
         do
         {
-            strm.next_out = out;
+            strm.next_out = reinterpret_cast<Bytef*>(out);
             strm.avail_out = chunk_size;
 
             ret = inflate(&strm, Z_NO_FLUSH);
@@ -85,8 +88,9 @@ std::vector<char> zlib_uncompress(
                 case Z_DATA_ERROR:
                 case Z_MEM_ERROR:
                     inflateEnd(&strm);
-                    throw std::system_error{ret, std::system_category(),
-                                            "Error calling inflate from zlib"};
+                    throw std::system_error{
+                        ret, std::system_category(),
+                        "Error calling inflate from zlib"};
             }
 
             have = chunk_size - strm.avail_out;
@@ -100,29 +104,31 @@ std::vector<char> zlib_uncompress(
     inflateEnd(&strm);
     if (ret != Z_STREAM_END)
     {
-        throw std::system_error{Z_DATA_ERROR, std::system_category(),
-                                "Error at end of inflation"};
+        throw std::system_error{
+            Z_DATA_ERROR, std::system_category(), "Error at end of inflation"};
     }
 
     return uncompressed;  // Named RVO
 }
 
 // Compress a byte array using zlib
-std::vector<char> zlib_compress(
-    const std::vector<char>& uncompressed, std::vector<char> compressed)
+std::vector<std::byte> zlib_compress(
+    const std::vector<std::byte>& uncompressed,
+    std::vector<std::byte> compressed)
 {
     // Put a placeholder four bytes to hold the uncompressed buffer size
     compressed.resize(4);
-    encode_int32_be(uncompressed.size(), compressed.data());
+    encode_int32_be(
+        static_cast<int32_t>(uncompressed.size()), compressed.data());
 
     // Compress
-    const char* ptr = &uncompressed[0];
-    const char* end = ptr + uncompressed.size();
+    auto* ptr = &uncompressed[0];
+    auto* end = ptr + uncompressed.size();
     const int chunk_size = 16384;
     int ret, flush;
     unsigned int have;
     z_stream strm;
-    unsigned char out[chunk_size];
+    std::byte out[chunk_size];
 
     // Allocate deflate state
     strm.zalloc = Z_NULL;
@@ -130,8 +136,8 @@ std::vector<char> zlib_compress(
     strm.opaque = Z_NULL;
     ret = deflateInit(&strm, Z_DEFAULT_COMPRESSION);
     if (ret != Z_OK)
-        throw std::system_error{ret, std::system_category(),
-                                "Error calling deflateInit from zlib"};
+        throw std::system_error{
+            ret, std::system_category(), "Error calling deflateInit from zlib"};
 
     // Compress until end of input
     do
@@ -153,10 +159,10 @@ std::vector<char> zlib_compress(
         // compression if all of source has been read in
         do
         {
-            strm.next_out = out;
+            strm.next_out = reinterpret_cast<Bytef*>(out);
             strm.avail_out = chunk_size;
 
-            ret = deflate(&strm, flush); /* no bad return value */
+            deflate(&strm, flush); /* no bad return value */
 
             have = chunk_size - strm.avail_out;
             compressed.insert(compressed.end(), out, out + have);

--- a/src/djinterop/engine/encode_decode_utils.hpp
+++ b/src/djinterop/engine/encode_decode_utils.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <tuple>
@@ -25,28 +26,31 @@
 namespace djinterop::engine
 {
 // Uncompress a zlib'ed BLOB
-std::vector<char> zlib_uncompress(
-    const std::vector<char>& compressed, std::vector<char> uncompressed = {});
+std::vector<std::byte> zlib_uncompress(
+    const std::vector<std::byte>& compressed,
+    std::vector<std::byte> uncompressed = {});
 
 // Compress a byte array using zlib
-std::vector<char> zlib_compress(
-    const std::vector<char>& uncompressed, std::vector<char> compressed = {});
+std::vector<std::byte> zlib_compress(
+    const std::vector<std::byte>& uncompressed,
+    std::vector<std::byte> compressed = {});
 
 // Extract an int8_t from a raw value at ptr address
-inline std::pair<uint8_t, const char*> decode_uint8(const char* ptr)
+inline std::pair<uint8_t, const std::byte*> decode_uint8(const std::byte* ptr)
 {
     return {static_cast<uint8_t>(*ptr), ptr + 1};
 }
 
 // Encode an uint8_t as a raw byte to an output pointer
-inline char* encode_uint8(uint8_t value, char* ptr)
+inline std::byte* encode_uint8(uint8_t value, std::byte* ptr)
 {
-    *ptr = static_cast<char>(value);
+    *ptr = static_cast<std::byte>(value);
     return ptr + 1;
 }
 
 // Decode an int32_t from a little-endian encoded raw value at ptr address
-inline std::pair<int32_t, const char*> decode_int32_le(const char* ptr)
+inline std::pair<int32_t, const std::byte*> decode_int32_le(
+    const std::byte* ptr)
 {
     int32_t value = static_cast<int32_t>(static_cast<uint8_t>(ptr[0])) |
                     static_cast<int32_t>(static_cast<uint8_t>(ptr[1]) << 8) |
@@ -56,17 +60,18 @@ inline std::pair<int32_t, const char*> decode_int32_le(const char* ptr)
 }
 
 // Encode an int32_t as 4 raw bytes to an output pointer with little-endianness
-inline char* encode_int32_le(int32_t value, char* ptr)
+inline std::byte* encode_int32_le(int32_t value, std::byte* ptr)
 {
-    ptr[0] = static_cast<char>(value);
-    ptr[1] = static_cast<char>(value >> 8);
-    ptr[2] = static_cast<char>(value >> 16);
-    ptr[3] = static_cast<char>(value >> 24);
+    ptr[0] = static_cast<std::byte>(value & 0xFF);
+    ptr[1] = static_cast<std::byte>((value >> 8) & 0xFF);
+    ptr[2] = static_cast<std::byte>((value >> 16) & 0xFF);
+    ptr[3] = static_cast<std::byte>((value >> 24) & 0xFF);
     return ptr + 4;
 }
 
 // Decode an int32_t from a big-endian encoded raw value at ptr address
-inline std::pair<int32_t, const char*> decode_int32_be(const char* ptr)
+inline std::pair<int32_t, const std::byte*> decode_int32_be(
+    const std::byte* ptr)
 {
     int32_t value = static_cast<int32_t>(static_cast<uint8_t>(ptr[0]) << 24) |
                     static_cast<int32_t>(static_cast<uint8_t>(ptr[1]) << 16) |
@@ -76,17 +81,18 @@ inline std::pair<int32_t, const char*> decode_int32_be(const char* ptr)
 }
 
 // Encode an int32_t as 4 raw bytes to an output pointer with big-endianness
-inline char* encode_int32_be(int32_t value, char* ptr)
+inline std::byte* encode_int32_be(int32_t value, std::byte* ptr)
 {
-    ptr[0] = static_cast<char>(value >> 24);
-    ptr[1] = static_cast<char>(value >> 16);
-    ptr[2] = static_cast<char>(value >> 8);
-    ptr[3] = static_cast<char>(value);
+    ptr[0] = static_cast<std::byte>((value >> 24) & 0xFF);
+    ptr[1] = static_cast<std::byte>((value >> 16) & 0xFF);
+    ptr[2] = static_cast<std::byte>((value >> 8) & 0xFF);
+    ptr[3] = static_cast<std::byte>(value & 0xFF);
     return ptr + 4;
 }
 
 // Decode an int64_t from a little-endian encoded raw value at ptr address
-inline std::pair<int64_t, const char*> decode_int64_le(const char* ptr)
+inline std::pair<int64_t, const std::byte*> decode_int64_le(
+    const std::byte* ptr)
 {
     int32_t e1, e2;
     std::tie(e1, ptr) = decode_int32_le(ptr);
@@ -97,7 +103,7 @@ inline std::pair<int64_t, const char*> decode_int64_le(const char* ptr)
 }
 
 // Encode an int64_t as 4 raw bytes to an output pointer with little-endianness
-inline char* encode_int64_le(int64_t value, char* ptr)
+inline std::byte* encode_int64_le(int64_t value, std::byte* ptr)
 {
     ptr = encode_int32_le(static_cast<int32_t>(value), ptr);
     ptr = encode_int32_le(static_cast<int32_t>(value >> 32), ptr);
@@ -105,7 +111,8 @@ inline char* encode_int64_le(int64_t value, char* ptr)
 }
 
 // Decode an int64_t from a big-endian encoded raw value at ptr address
-inline std::pair<int64_t, const char*> decode_int64_be(const char* ptr)
+inline std::pair<int64_t, const std::byte*> decode_int64_be(
+    const std::byte* ptr)
 {
     int32_t e1, e2;
     std::tie(e1, ptr) = decode_int32_be(ptr);
@@ -116,7 +123,7 @@ inline std::pair<int64_t, const char*> decode_int64_be(const char* ptr)
 }
 
 // Encode an int64_t as 4 raw bytes to an output pointer with big-endianness
-inline char* encode_int64_be(int64_t value, char* ptr)
+inline std::byte* encode_int64_be(int64_t value, std::byte* ptr)
 {
     ptr = encode_int32_be(static_cast<int32_t>(value >> 32), ptr);
     ptr = encode_int32_be(static_cast<int32_t>(value), ptr);
@@ -124,7 +131,8 @@ inline char* encode_int64_be(int64_t value, char* ptr)
 }
 
 // Decode a double from a little-endian encoded raw value at ptr address
-inline std::pair<double, const char*> decode_double_le(const char* ptr)
+inline std::pair<double, const std::byte*> decode_double_le(
+    const std::byte* ptr)
 {
     int64_t value;
     std::tie(value, ptr) = decode_int64_le(ptr);
@@ -134,7 +142,7 @@ inline std::pair<double, const char*> decode_double_le(const char* ptr)
 }
 
 // Encode a double as 8 raw bytes to an output pointer with little-endianness
-inline char* encode_double_le(double value, char* ptr)
+inline std::byte* encode_double_le(double value, std::byte* ptr)
 {
     int64_t temp;
     std::memcpy(&temp, &value, 8);
@@ -142,7 +150,8 @@ inline char* encode_double_le(double value, char* ptr)
 }
 
 // Decode a double from a big-endian encoded raw value at ptr address
-inline std::pair<double, const char*> decode_double_be(const char* ptr)
+inline std::pair<double, const std::byte*> decode_double_be(
+    const std::byte* ptr)
 {
     int64_t value;
     std::tie(value, ptr) = decode_int64_be(ptr);
@@ -152,11 +161,29 @@ inline std::pair<double, const char*> decode_double_be(const char* ptr)
 }
 
 // Encode a double as 8 raw bytes to an output pointer with big-endianness
-inline char* encode_double_be(double value, char* ptr)
+inline std::byte* encode_double_be(double value, std::byte* ptr)
 {
     int64_t temp;
     std::memcpy(&temp, &value, 8);
     return encode_int64_be(temp, ptr);
+}
+
+// Decode any extra data at the end of a buffer to a new buffer for extra data.
+inline std::pair<std::vector<std::byte>, const std::byte*> decode_extra(
+    const std::byte* ptr, const std::byte* end)
+{
+    std::vector<std::byte> extra_data;
+    extra_data.resize(end - ptr);
+    std::memcpy(extra_data.data(), ptr, extra_data.size());
+    return {extra_data, ptr + extra_data.size()};
+}
+
+// Encode extra data verbatim.
+inline std::byte* encode_extra(
+    const std::vector<std::byte>& extra_data, std::byte* ptr)
+{
+    std::memcpy(ptr, extra_data.data(), extra_data.size());
+    return ptr + extra_data.size();
 }
 
 }  // namespace djinterop::engine

--- a/src/djinterop/engine/v1/engine_storage.cpp
+++ b/src/djinterop/engine/v1/engine_storage.cpp
@@ -17,6 +17,7 @@
 
 #include "engine_storage.hpp"
 
+#include <cstddef>
 #include <utility>
 
 #include <djinterop/database.hpp>
@@ -782,12 +783,12 @@ performance_data_row engine_storage::get_performance_data(int64_t id)
               "FROM PerformanceData WHERE id = ?"
            << id >>
             [&](int64_t id, int64_t is_analyzed, int64_t is_rendered,
-                const std::vector<char>& track_data_blob,
-                const std::vector<char>& high_res_waveform_data_blob,
-                const std::vector<char>& overview_waveform_data_blob,
-                const std::vector<char>& beat_data_blob,
-                const std::vector<char>& quick_cues_data_blob,
-                const std::vector<char>& loops_data_blob,
+                const std::vector<std::byte>& track_data_blob,
+                const std::vector<std::byte>& high_res_waveform_data_blob,
+                const std::vector<std::byte>& overview_waveform_data_blob,
+                const std::vector<std::byte>& beat_data_blob,
+                const std::vector<std::byte>& quick_cues_data_blob,
+                const std::vector<std::byte>& loops_data_blob,
                 int64_t has_serato_values, int64_t has_rekordbox_values,
                 int64_t has_traktor_values) {
                 if (result)
@@ -820,12 +821,12 @@ performance_data_row engine_storage::get_performance_data(int64_t id)
               "FROM PerformanceData WHERE id = ?"
            << id >>
             [&](int64_t id, int64_t is_analyzed, int64_t is_rendered,
-                const std::vector<char>& track_data_blob,
-                const std::vector<char>& high_res_waveform_data_blob,
-                const std::vector<char>& overview_waveform_data_blob,
-                const std::vector<char>& beat_data_blob,
-                const std::vector<char>& quick_cues_data_blob,
-                const std::vector<char>& loops_data_blob,
+                const std::vector<std::byte>& track_data_blob,
+                const std::vector<std::byte>& high_res_waveform_data_blob,
+                const std::vector<std::byte>& overview_waveform_data_blob,
+                const std::vector<std::byte>& beat_data_blob,
+                const std::vector<std::byte>& quick_cues_data_blob,
+                const std::vector<std::byte>& loops_data_blob,
                 int64_t has_serato_values, int64_t has_rekordbox_values) {
                 if (result)
                 {
@@ -857,12 +858,12 @@ performance_data_row engine_storage::get_performance_data(int64_t id)
               "FROM PerformanceData WHERE id = ?"
            << id >>
             [&](int64_t id, int64_t is_analyzed, int64_t is_rendered,
-                const std::vector<char>& track_data_blob,
-                const std::vector<char>& high_res_waveform_data_blob,
-                const std::vector<char>& overview_waveform_data_blob,
-                const std::vector<char>& beat_data_blob,
-                const std::vector<char>& quick_cues_data_blob,
-                const std::vector<char>& loops_data_blob,
+                const std::vector<std::byte>& track_data_blob,
+                const std::vector<std::byte>& high_res_waveform_data_blob,
+                const std::vector<std::byte>& overview_waveform_data_blob,
+                const std::vector<std::byte>& beat_data_blob,
+                const std::vector<std::byte>& quick_cues_data_blob,
+                const std::vector<std::byte>& loops_data_blob,
                 int64_t has_serato_values) {
                 if (result)
                 {

--- a/src/djinterop/engine/v1/engine_storage.hpp
+++ b/src/djinterop/engine/v1/engine_storage.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -249,7 +250,7 @@ public:
         db << (std::string{"SELECT "} + column_name +
                " FROM PerformanceData WHERE id = ?")
            << id >>
-            [&](const std::vector<char>& encoded_data) {
+            [&](const std::vector<std::byte>& encoded_data) {
                 if (!result)
                 {
                     result = T::decode(encoded_data);

--- a/src/djinterop/engine/v1/performance_data_format.hpp
+++ b/src/djinterop/engine/v1/performance_data_format.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -47,8 +48,8 @@ struct beat_data
                first.adjusted_beatgrid == second.adjusted_beatgrid;
     }
 
-    std::vector<char> encode() const;
-    static beat_data decode(const std::vector<char>& compressed_data);
+    std::vector<std::byte> encode() const;
+    static beat_data decode(const std::vector<std::byte>& compressed_data);
 };
 
 struct high_res_waveform_data
@@ -66,9 +67,9 @@ struct high_res_waveform_data
                first.waveform == second.waveform;
     }
 
-    std::vector<char> encode() const;
+    std::vector<std::byte> encode() const;
     static high_res_waveform_data decode(
-        const std::vector<char>& compressed_data);
+        const std::vector<std::byte>& compressed_data);
 };
 
 struct loops_data
@@ -83,9 +84,9 @@ struct loops_data
         return first.loops == second.loops;
     }
 
-    std::vector<char> encode() const;
+    std::vector<std::byte> encode() const;
     static loops_data decode(
-        const std::vector<char>& raw_data);  // not compressed
+        const std::vector<std::byte>& raw_data);  // not compressed
 };
 
 struct overview_waveform_data
@@ -103,9 +104,9 @@ struct overview_waveform_data
                first.waveform == second.waveform;
     }
 
-    std::vector<char> encode() const;
+    std::vector<std::byte> encode() const;
     static overview_waveform_data decode(
-        const std::vector<char>& compressed_data);
+        const std::vector<std::byte>& compressed_data);
 };
 
 struct quick_cues_data
@@ -124,8 +125,8 @@ struct quick_cues_data
                first.default_main_cue == second.default_main_cue;
     }
 
-    std::vector<char> encode() const;
-    static quick_cues_data decode(const std::vector<char>& compressed_data);
+    std::vector<std::byte> encode() const;
+    static quick_cues_data decode(const std::vector<std::byte>& compressed_data);
 };
 
 struct track_data
@@ -146,8 +147,8 @@ struct track_data
                first.key == second.key;
     }
 
-    std::vector<char> encode() const;
-    static track_data decode(const std::vector<char>& compressed_data);
+    std::vector<std::byte> encode() const;
+    static track_data decode(const std::vector<std::byte>& compressed_data);
 };
 
 }  // namespace engine::v1

--- a/src/djinterop/engine/v2/convert_track.hpp
+++ b/src/djinterop/engine/v2/convert_track.hpp
@@ -43,8 +43,8 @@ inline stdx::optional<int64_t> album_art_id(int64_t album_art_id)
 inline stdx::optional<double> average_loudness(
     const track_data_blob& track_data)
 {
-    return track_data.average_loudness != 0
-               ? stdx::make_optional(track_data.average_loudness)
+    return track_data.average_loudness_1 != 0
+               ? stdx::make_optional(track_data.average_loudness_1)
                : stdx::nullopt;
 }
 

--- a/src/djinterop/engine/v2/track_data_blob.cpp
+++ b/src/djinterop/engine/v2/track_data_blob.cpp
@@ -25,28 +25,31 @@
 
 namespace djinterop::engine::v2
 {
-std::vector<char> track_data_blob::to_blob() const
+std::vector<std::byte> track_data_blob::to_blob() const
 {
-    std::vector<char> uncompressed(28);  // Track data has fixed size
+    std::vector<std::byte> uncompressed(44 + extra_data.size());
     auto ptr = uncompressed.data();
     const auto end = ptr + uncompressed.size();
 
     ptr = encode_double_be(sample_rate, ptr);
     ptr = encode_int64_be(samples, ptr);
-    ptr = encode_double_be(average_loudness, ptr);
     ptr = encode_int32_be(key, ptr);
+    ptr = encode_double_be(average_loudness_1, ptr);
+    ptr = encode_double_be(average_loudness_2, ptr);
+    ptr = encode_double_be(average_loudness_3, ptr);
+    ptr = encode_extra(extra_data, ptr);
     assert(ptr == end);
 
     return zlib_compress(uncompressed);
 }
 
-track_data_blob track_data_blob::from_blob(const std::vector<char>& blob)
+track_data_blob track_data_blob::from_blob(const std::vector<std::byte>& blob)
 {
     const auto uncompressed = zlib_uncompress(blob);
     auto ptr = uncompressed.data();
     const auto end = ptr + uncompressed.size();
 
-    if (uncompressed.size() != 28)
+    if (uncompressed.size() != 44)
     {
         throw std::invalid_argument{
             "Track data blob doesn't have expected decompressed length of 28 "
@@ -56,8 +59,11 @@ track_data_blob track_data_blob::from_blob(const std::vector<char>& blob)
     track_data_blob result{};
     std::tie(result.sample_rate, ptr) = decode_double_be(ptr);
     std::tie(result.samples, ptr) = decode_int64_be(ptr);
-    std::tie(result.average_loudness, ptr) = decode_double_be(ptr);
     std::tie(result.key, ptr) = decode_int32_be(ptr);
+    std::tie(result.average_loudness_1, ptr) = decode_double_be(ptr);
+    std::tie(result.average_loudness_2, ptr) = decode_double_be(ptr);
+    std::tie(result.average_loudness_3, ptr) = decode_double_be(ptr);
+    std::tie(result.extra_data, ptr) = decode_extra(ptr, end);
     assert(ptr == end);
 
     return result;

--- a/src/djinterop/engine/v2/track_impl.cpp
+++ b/src/djinterop/engine/v2/track_impl.cpp
@@ -116,8 +116,7 @@ track_row snapshot_to_row(
     quick_cues_blob quick_cues;
     quick_cues.default_main_cue = convert::write::main_cue(snapshot.main_cue);
     quick_cues.adjusted_main_cue = convert::write::main_cue(snapshot.main_cue);
-    quick_cues.is_main_cue_adjusted =
-        quick_cues.default_main_cue != quick_cues.adjusted_main_cue;
+    quick_cues.is_main_cue_adjusted = true;
     quick_cues.quick_cues = convert::write::hot_cues(snapshot.hot_cues);
 
     loops_blob loops = convert::write::loops(snapshot.loops);
@@ -513,6 +512,7 @@ void track_impl::set_main_cue(stdx::optional<double> sample_offset)
     auto quick_cues = track_.get_quick_cues(id());
     quick_cues.adjusted_main_cue = sample_offset.value_or(0);
     quick_cues.default_main_cue = sample_offset.value_or(0);
+    quick_cues.is_main_cue_adjusted = true;
     track_.set_quick_cues(id(), quick_cues);
 }
 

--- a/src/djinterop/engine/v2/track_impl.cpp
+++ b/src/djinterop/engine/v2/track_impl.cpp
@@ -93,18 +93,25 @@ track_row snapshot_to_row(
         convert::write::sample_rate(snapshot.sample_rate);
 
     track_data_blob track_data{
-        converted_sample_rate, converted_sample_count.track_data_samples,
-        converted_average_loudness, converted_key.track_data_key};
+        converted_sample_rate,        converted_sample_count.track_data_samples,
+        converted_key.track_data_key, converted_average_loudness,
+        converted_average_loudness,   converted_average_loudness};
 
     auto overview_waveform_data = convert::write::waveform(
         snapshot.waveform, snapshot.sample_count, snapshot.sample_rate);
 
     auto converted_beatgrid = convert::write::beatgrid(snapshot.beatgrid);
+
+    // Real beat data seems to have 9 additional zero bytes at the end!
+    std::vector<std::byte> beat_data_extra(9, std::byte{0});
+
     beat_data_blob beat_data{
-        converted_sample_rate, converted_sample_count.beat_data_samples,
+        converted_sample_rate,
+        converted_sample_count.beat_data_samples,
         converted_beatgrid.is_beatgrid_set,
         converted_beatgrid.default_beat_grid,
-        converted_beatgrid.adjusted_beat_grid};
+        converted_beatgrid.adjusted_beat_grid,
+        beat_data_extra};
 
     quick_cues_blob quick_cues;
     quick_cues.default_main_cue = convert::write::main_cue(snapshot.main_cue);
@@ -267,8 +274,10 @@ stdx::optional<double> track_impl::average_loudness()
 void track_impl::set_average_loudness(stdx::optional<double> average_loudness)
 {
     auto track_data = track_.get_track_data(id());
-    track_data.average_loudness =
-        convert::write::average_loudness(average_loudness);
+    auto converted = convert::write::average_loudness(average_loudness);
+    track_data.average_loudness_1 = converted;
+    track_data.average_loudness_2 = converted;
+    track_data.average_loudness_3 = converted;
     track_.set_track_data(id(), track_data);
 }
 

--- a/src/djinterop/engine/v2/track_table.cpp
+++ b/src/djinterop/engine/v2/track_table.cpp
@@ -18,6 +18,7 @@
 #include <djinterop/engine/v2/track_table.hpp>
 
 #include <cassert>
+#include <cstddef>
 #include <utility>
 
 #include <djinterop/engine/v2/engine_library_context.hpp>
@@ -388,8 +389,7 @@ stdx::optional<track_row> track_table::get(int64_t id) const
                 stdx::optional<int32_t> key, int64_t rating,
                 stdx::optional<std::string> album_art,
                 stdx::optional<int64_t> time_last_played, bool is_played,
-                std::string file_type, bool is_analyzed,
-                int64_t date_created,
+                std::string file_type, bool is_analyzed, int64_t date_created,
                 int64_t date_added, bool is_available,
                 bool is_metadata_of_packed_track_changed,
                 bool is_performance_data_of_packed_track_changed,
@@ -398,11 +398,11 @@ stdx::optional<track_row> track_table::get(int64_t id) const
                 stdx::optional<std::string> streaming_source,
                 stdx::optional<std::string> uri, bool is_beat_grid_locked,
                 std::string origin_database_uuid, int64_t origin_track_id,
-                const std::vector<char>& track_data,
-                const std::vector<char>& overview_waveform_data,
-                const std::vector<char>& beat_data,
-                const std::vector<char>& quick_cues,
-                const std::vector<char>& loops,
+                const std::vector<std::byte>& track_data,
+                const std::vector<std::byte>& overview_waveform_data,
+                const std::vector<std::byte>& beat_data,
+                const std::vector<std::byte>& quick_cues,
+                const std::vector<std::byte>& loops,
                 stdx::optional<int64_t> third_party_source_id,
                 int64_t streaming_flags, bool explicit_lyrics,
                 stdx::optional<int64_t> active_on_load_loops,
@@ -497,8 +497,7 @@ stdx::optional<track_row> track_table::get(int64_t id) const
                 stdx::optional<int32_t> key, int64_t rating,
                 stdx::optional<std::string> album_art,
                 stdx::optional<int64_t> time_last_played, bool is_played,
-                std::string file_type, bool is_analyzed,
-                int64_t date_created,
+                std::string file_type, bool is_analyzed, int64_t date_created,
                 int64_t date_added, bool is_available,
                 bool is_metadata_of_packed_track_changed,
                 bool is_performance_data_of_packed_track_changed,
@@ -507,11 +506,11 @@ stdx::optional<track_row> track_table::get(int64_t id) const
                 stdx::optional<std::string> streaming_source,
                 stdx::optional<std::string> uri, bool is_beat_grid_locked,
                 std::string origin_database_uuid, int64_t origin_track_id,
-                const std::vector<char>& track_data,
-                const std::vector<char>& overview_waveform_data,
-                const std::vector<char>& beat_data,
-                const std::vector<char>& quick_cues,
-                const std::vector<char>& loops,
+                const std::vector<std::byte>& track_data,
+                const std::vector<std::byte>& overview_waveform_data,
+                const std::vector<std::byte>& beat_data,
+                const std::vector<std::byte>& quick_cues,
+                const std::vector<std::byte>& loops,
                 stdx::optional<int64_t> third_party_source_id,
                 int64_t streaming_flags, bool explicit_lyrics,
                 stdx::optional<int64_t> active_on_load_loops)
@@ -604,8 +603,7 @@ stdx::optional<track_row> track_table::get(int64_t id) const
                 stdx::optional<int32_t> key, int64_t rating,
                 stdx::optional<std::string> album_art,
                 stdx::optional<int64_t> time_last_played, bool is_played,
-                std::string file_type, bool is_analyzed,
-                int64_t date_created,
+                std::string file_type, bool is_analyzed, int64_t date_created,
                 int64_t date_added, bool is_available,
                 bool is_metadata_of_packed_track_changed,
                 bool is_performance_data_of_packed_track_changed,
@@ -614,11 +612,11 @@ stdx::optional<track_row> track_table::get(int64_t id) const
                 stdx::optional<std::string> streaming_source,
                 stdx::optional<std::string> uri, bool is_beat_grid_locked,
                 std::string origin_database_uuid, int64_t origin_track_id,
-                const std::vector<char>& track_data,
-                const std::vector<char>& overview_waveform_data,
-                const std::vector<char>& beat_data,
-                const std::vector<char>& quick_cues,
-                const std::vector<char>& loops,
+                const std::vector<std::byte>& track_data,
+                const std::vector<std::byte>& overview_waveform_data,
+                const std::vector<std::byte>& beat_data,
+                const std::vector<std::byte>& quick_cues,
+                const std::vector<std::byte>& loops,
                 stdx::optional<int64_t> third_party_source_id,
                 int64_t streaming_flags, bool explicit_lyrics)
         {
@@ -1298,26 +1296,26 @@ void track_table::set_origin_track_id(int64_t id, int64_t origin_track_id)
 track_data_blob track_table::get_track_data(int64_t id)
 {
     return track_data_blob::from_blob(
-        get_column<std::vector<char> >(context_->db, id, "trackData"));
+        get_column<std::vector<std::byte> >(context_->db, id, "trackData"));
 }
 
 void track_table::set_track_data(int64_t id, const track_data_blob& track_data)
 {
-    set_column<std::vector<char> >(
+    set_column<std::vector<std::byte> >(
         context_->db, id, "trackData", track_data.to_blob());
 }
 
 overview_waveform_data_blob track_table::get_overview_waveform_data(int64_t id)
 {
     return overview_waveform_data_blob::from_blob(
-        get_column<std::vector<char> >(
+        get_column<std::vector<std::byte> >(
             context_->db, id, "overviewWaveFormData"));
 }
 
 void track_table::set_overview_waveform_data(
     int64_t id, const overview_waveform_data_blob& overview_waveform_data)
 {
-    set_column<std::vector<char> >(
+    set_column<std::vector<std::byte> >(
         context_->db, id, "overviewWaveFormData",
         overview_waveform_data.to_blob());
 }
@@ -1325,36 +1323,37 @@ void track_table::set_overview_waveform_data(
 beat_data_blob track_table::get_beat_data(int64_t id)
 {
     return beat_data_blob::from_blob(
-        get_column<std::vector<char> >(context_->db, id, "beatData"));
+        get_column<std::vector<std::byte> >(context_->db, id, "beatData"));
 }
 
 void track_table::set_beat_data(int64_t id, const beat_data_blob& beat_data)
 {
-    set_column<std::vector<char> >(
+    set_column<std::vector<std::byte> >(
         context_->db, id, "beatData", beat_data.to_blob());
 }
 
 quick_cues_blob track_table::get_quick_cues(int64_t id)
 {
     return quick_cues_blob::from_blob(
-        get_column<std::vector<char> >(context_->db, id, "quickCues"));
+        get_column<std::vector<std::byte> >(context_->db, id, "quickCues"));
 }
 
 void track_table::set_quick_cues(int64_t id, const quick_cues_blob& quick_cues)
 {
-    set_column<std::vector<char> >(
+    set_column<std::vector<std::byte> >(
         context_->db, id, "quickCues", quick_cues.to_blob());
 }
 
 loops_blob track_table::get_loops(int64_t id)
 {
     return loops_blob::from_blob(
-        get_column<std::vector<char> >(context_->db, id, "loops"));
+        get_column<std::vector<std::byte> >(context_->db, id, "loops"));
 }
 
 void track_table::set_loops(int64_t id, const loops_blob& loops)
 {
-    set_column<std::vector<char> >(context_->db, id, "loops", loops.to_blob());
+    set_column<std::vector<std::byte> >(
+        context_->db, id, "loops", loops.to_blob());
 }
 
 stdx::optional<int64_t> track_table::get_third_party_source_id(int64_t id)

--- a/test/djinterop/engine/v2/example_track_row_data.hpp
+++ b/test/djinterop/engine/v2/example_track_row_data.hpp
@@ -164,7 +164,7 @@ inline void populate_track_row(
             r.is_beat_grid_locked = false;
             r.origin_database_uuid = "e423f29c-fb50-4ddc-b730-fd1d6534b022";
             r.origin_track_id = 12345;
-            r.track_data = ev2::track_data_blob{41000, 5424300, 0.5, 1};
+            r.track_data = ev2::track_data_blob{41000, 5424300, 1, 0.5, 0.5, 0.5};
             r.overview_waveform_data = ev2::overview_waveform_data_blob{};
             auto beatgrid = std::vector<ev2::beat_grid_marker_blob>{};
             beatgrid.push_back(ev2::beat_grid_marker_blob{0, 1, 16, 0});

--- a/test/djinterop/engine/v2/playlist_entity_table_test.cpp
+++ b/test/djinterop/engine/v2/playlist_entity_table_test.cpp
@@ -168,7 +168,7 @@ BOOST_DATA_TEST_CASE(
     auto p_id = playlist_tbl.add(p_row);
     ev2::playlist_entity_row pe_row{
         ev2::PLAYLIST_ENTITY_ROW_ID_NONE, p_id, EXAMPLE_TRACK_ID_1, db_uuid};
-    auto pe_id = playlist_entity_tbl.add_back(pe_row);
+    playlist_entity_tbl.add_back(pe_row);
 
     // Act/Assert
     BOOST_CHECK_THROW(


### PR DESCRIPTION
* Change encoded blob representation to `std::byte` rather than `char`.
* Preserve extra binary data when decoding/encoding blobs.  This can help with compatibility of future versions, as mentioned in #99.
* Fix some string-rendering typos.
* Update the track data format to the new "v2" arrangement, which is backwards-incompatible with v1.
* Always set the cue point to be "adjusted" in the high-level API, as otherwise hardware players will default to their own derived one.