### PR TITLE
fix Clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
 else()
     add_compile_options("-Wall" "$<$<CONFIG:RELEASE>:-O3>")
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        add_compile_options("-stdlib=libc++")
-    endif()
 endif()
 
 


### PR DESCRIPTION
don't force `-stdlib=libc++`

Fixes https://github.com/xsco/libdjinterop/issues/112