### PR TITLE
only compile with -Wall for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(MSVC)
     # Ask MSVC to populate the __cplusplus macro properly.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
 else()
-    add_compile_options("-Wall" "$<$<CONFIG:RELEASE>:-O3>")
+    add_compile_options("$<$<CONFIG:DEBUG>:-Wall>")
 endif()
 
 


### PR DESCRIPTION
Using -Wall on release builds can break builds of old code in the future when compilers add warnings that didn't exist when the code was written.

Also remove superfluous specification of -O3 for release builds; CMake does this by default.
