### PR TITLE
Create crates in order (for Engine V2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(libdjinterop
-        VERSION 0.20.3
+        VERSION 0.21.0
         DESCRIPTION "C++ library providing access to DJ record libraries")
 set(PROJECT_HOMEPAGE_URL "https://github.com/xsco/libdjinterop")
 

--- a/include/djinterop/crate.hpp
+++ b/include/djinterop/crate.hpp
@@ -85,8 +85,12 @@ public:
     /// zero crates.
     void clear_tracks() const;
 
-    /// Creates a new, empty crate as a child of this one, and returns it.
-    crate create_sub_crate(std::string name);
+    /// Create a new crate as a child of this one.
+    crate create_sub_crate(const std::string& name);
+
+    /// Create a new crate as a child of this one, after the given crate in
+    /// order.
+    crate create_sub_crate_after(const std::string& name, const crate& after);
 
     /// Returns the database containing the crate
     database db() const;

--- a/include/djinterop/database.hpp
+++ b/include/djinterop/database.hpp
@@ -65,10 +65,11 @@ public:
     /// Returns all crates with the given name
     std::vector<crate> crates_by_name(const std::string& name) const;
 
-    /// Creates a new root crate with the given name.
-    ///
-    /// The created crate has no parent.
-    crate create_root_crate(std::string name) const;
+    /// Create a new root crate with the given name.  The created crate has no parent.
+    crate create_root_crate(const std::string& name);
+
+    /// Create a new root crate with the given name, after the given crate in order.
+    crate create_root_crate_after(const std::string& name, const crate& after);
 
     /// Create a new track in the database, given a pre-populated track
     /// snapshot.

--- a/src/djinterop/crate.cpp
+++ b/src/djinterop/crate.cpp
@@ -21,6 +21,7 @@
 #include <djinterop/djinterop.hpp>
 
 #include "impl/crate_impl.hpp"
+#include "djinterop/crate.hpp"
 
 namespace djinterop
 {
@@ -50,9 +51,14 @@ void crate::clear_tracks() const
     pimpl_->clear_tracks();
 }
 
-crate crate::create_sub_crate(std::string name)
+crate crate::create_sub_crate(const std::string& name)
 {
     return pimpl_->create_sub_crate(name);
+}
+
+crate crate::create_sub_crate_after(const std::string& name, const crate& after)
+{
+    return pimpl_-> create_sub_crate_after(name, after);
 }
 
 database crate::db() const

--- a/src/djinterop/database.cpp
+++ b/src/djinterop/database.cpp
@@ -20,6 +20,8 @@
 #include <djinterop/djinterop.hpp>
 
 #include "impl/database_impl.hpp"
+#include "djinterop/database.hpp"
+
 
 namespace djinterop
 {
@@ -44,9 +46,14 @@ std::vector<crate> database::crates_by_name(const std::string& name) const
     return pimpl_->crates_by_name(name);
 }
 
-crate database::create_root_crate(std::string name) const
+crate database::create_root_crate(const std::string& name)
 {
     return pimpl_->create_root_crate(name);
+}
+
+crate database::create_root_crate_after(const std::string &name, const crate &after)
+{
+    return pimpl_->create_root_crate_after(name, after);
 }
 
 track database::create_track(const track_snapshot& snapshot)

--- a/src/djinterop/engine/v1/engine_crate_impl.cpp
+++ b/src/djinterop/engine/v1/engine_crate_impl.cpp
@@ -125,7 +125,7 @@ void engine_crate_impl::clear_tracks()
     storage_->db << "DELETE FROM CrateTrackList WHERE crateId = ?" << id();
 }
 
-crate engine_crate_impl::create_sub_crate(std::string name)
+crate engine_crate_impl::create_sub_crate(const std::string& name)
 {
     ensure_valid_name(name);
     util::sqlite_transaction trans{storage_->db};
@@ -180,6 +180,13 @@ crate engine_crate_impl::create_sub_crate(std::string name)
     trans.commit();
 
     return cr;
+}
+
+crate engine_crate_impl::create_sub_crate_after(
+    const std::string& name, [[maybe_unused]] const crate& after)
+{
+    // TODO (mr-smidge): Back-port sorted crate functionality to Engine V1.
+    return create_sub_crate(name);
 }
 
 database engine_crate_impl::db()

--- a/src/djinterop/engine/v1/engine_crate_impl.hpp
+++ b/src/djinterop/engine/v1/engine_crate_impl.hpp
@@ -36,7 +36,9 @@ public:
     void add_track(track tr) override;
     std::vector<crate> children() override;
     void clear_tracks() override;
-    crate create_sub_crate(std::string name) override;
+    crate create_sub_crate(const std::string& name) override;
+    crate create_sub_crate_after(
+        const std::string& name, const crate& after) override;
     database db() override;
     std::vector<crate> descendants() override;
     bool is_valid() override;

--- a/src/djinterop/engine/v1/engine_database_impl.cpp
+++ b/src/djinterop/engine/v1/engine_database_impl.cpp
@@ -89,7 +89,7 @@ std::vector<crate> engine_database_impl::crates_by_name(const std::string& name)
     return results;
 }
 
-crate engine_database_impl::create_root_crate(std::string name)
+crate engine_database_impl::create_root_crate(const std::string& name)
 {
     ensure_valid_crate_name(name);
     djinterop::util::sqlite_transaction trans{storage_->db};
@@ -123,6 +123,13 @@ crate engine_database_impl::create_root_crate(std::string name)
     trans.commit();
 
     return cr;
+}
+
+crate engine_database_impl::create_root_crate_after(
+    const std::string& name, [[maybe_unused]] const crate& after)
+{
+    // TODO (mr-smidge): Back-port sorted crate functionality to Engine V1.
+   return create_root_crate(name);
 }
 
 track engine_database_impl::create_track(const track_snapshot& snapshot)

--- a/src/djinterop/engine/v1/engine_database_impl.hpp
+++ b/src/djinterop/engine/v1/engine_database_impl.hpp
@@ -33,7 +33,9 @@ public:
     std::vector<djinterop::crate> crates() override;
     std::vector<djinterop::crate> crates_by_name(
         const std::string& name) override;
-    djinterop::crate create_root_crate(std::string name) override;
+    crate create_root_crate(const std::string& name) override;
+    crate create_root_crate_after(
+        const std::string& name, const crate& after) override;
     track create_track(const track_snapshot& snapshot) override;
     std::string directory() override;
     void verify() override;

--- a/src/djinterop/engine/v2/crate_impl.hpp
+++ b/src/djinterop/engine/v2/crate_impl.hpp
@@ -41,7 +41,9 @@ public:
     void add_track(track tr) override;
     std::vector<crate> children() override;
     void clear_tracks() override;
-    crate create_sub_crate(std::string name) override;
+    crate create_sub_crate(const std::string& name) override;
+    crate create_sub_crate_after(
+        const std::string& name, const crate& after) override;
     database db() override;
     std::vector<crate> descendants() override;
     bool is_valid() override;

--- a/src/djinterop/engine/v2/database_impl.hpp
+++ b/src/djinterop/engine/v2/database_impl.hpp
@@ -36,7 +36,9 @@ public:
     std::vector<djinterop::crate> crates() override;
     std::vector<djinterop::crate> crates_by_name(
         const std::string& name) override;
-    djinterop::crate create_root_crate(std::string name) override;
+    crate create_root_crate(const std::string& name) override;
+    crate create_root_crate_after(
+        const std::string& name, const crate& after) override;
     track create_track(const track_snapshot& snapshot) override;
     std::string directory() override;
     void verify() override;

--- a/src/djinterop/impl/crate_impl.hpp
+++ b/src/djinterop/impl/crate_impl.hpp
@@ -43,7 +43,9 @@ public:
     virtual void add_track(track tr) = 0;
     virtual std::vector<crate> children() = 0;
     virtual void clear_tracks() = 0;
-    virtual crate create_sub_crate(std::string name) = 0;
+    virtual crate create_sub_crate(const std::string& name) = 0;
+    virtual crate create_sub_crate_after(
+        const std::string& name, const crate& after) = 0;
     virtual database db() = 0;
     virtual std::vector<crate> descendants() = 0;
     virtual bool is_valid() = 0;

--- a/src/djinterop/impl/database_impl.hpp
+++ b/src/djinterop/impl/database_impl.hpp
@@ -36,7 +36,9 @@ public:
     virtual stdx::optional<crate> crate_by_id(int64_t id) = 0;
     virtual std::vector<crate> crates() = 0;
     virtual std::vector<crate> crates_by_name(const std::string& name) = 0;
-    virtual crate create_root_crate(std::string name) = 0;
+    virtual crate create_root_crate(const std::string& name) = 0;
+    virtual crate create_root_crate_after(
+        const std::string& name, const crate& after) = 0;
     virtual track create_track(const track_snapshot& snapshot) = 0;
     virtual std::string directory() = 0;
     virtual void verify() = 0;

--- a/test/djinterop/engine/database_test.cpp
+++ b/test/djinterop/engine/database_test.cpp
@@ -40,7 +40,7 @@ namespace e = djinterop::engine;
 BOOST_TEST_DECORATOR(* utf::description(
     "database::create_root_crate() for all supported schema versions"))
 BOOST_DATA_TEST_CASE(
-    create_root_crate__supported_version__creates, e::all_v1_versions, version)
+    create_root_crate__supported_version__creates, e::all_versions, version)
 {
     // Arrange
     BOOST_TEST_CHECKPOINT("(" << version << ") Creating temporary database...");
@@ -53,6 +53,34 @@ BOOST_DATA_TEST_CASE(
     // Assert
     BOOST_CHECK_NE(crate.id(), 0);
     BOOST_CHECK(crate.parent() == djinterop::stdx::nullopt);
+}
+
+BOOST_TEST_DECORATOR(* utf::description(
+    "database::create_root_crate_after() for all supported schema versions"))
+BOOST_DATA_TEST_CASE(
+    create_root_crate_after__supported_version__creates, e::all_v2_versions,
+    version)
+{
+    // Arrange
+    BOOST_TEST_CHECKPOINT("(" << version << ") Creating temporary database...");
+    auto db = e::create_temporary_database(version);
+    auto crate_a = db.create_root_crate("Example Root Crate A");
+    auto crate_b = db.create_root_crate("Example Root Crate B");
+    auto crate_d = db.create_root_crate("Example Root Crate D");
+    auto crate_e = db.create_root_crate("Example Root Crate E");
+
+    // Act
+    BOOST_TEST_CHECKPOINT("(" << version << ") Creating root crate after another...");
+    auto crate = db.create_root_crate_after("Example Root Crate C", crate_b);
+
+    // Assert
+    auto crates = db.root_crates();
+    BOOST_CHECK_EQUAL(5, crates.size());
+    BOOST_CHECK(crates[0].id() == crate_a.id());
+    BOOST_CHECK(crates[1].id() == crate_b.id());
+    BOOST_CHECK(crates[2].id() == crate.id());
+    BOOST_CHECK(crates[3].id() == crate_d.id());
+    BOOST_CHECK(crates[4].id() == crate_e.id());
 }
 
 BOOST_TEST_DECORATOR(* utf::description(


### PR DESCRIPTION
New method `create_..._after()` provides the ability to maintain a sorted list of crates.  Pseudo-code as follows could achieve this:

```cpp
djinterop::crate create_sorted(djinterop::database& db, const std::string& name)
{
  for (auto&& crate : db.root_crates())  // Assume already sorted
  {
    if (name > crate.name())
    {
      return db.create_root_crate_after(name, crate);
    }
  }

  return db.create_root_crate(name);
}
```

At present this is only implemented for Engine V2, which makes the process easy via its DB triggers.  The DB schema in Engine V1 would require a little extra work that is not high priority now, given that Engine 1.x is not readily used any longer.

Fixes #117.