### PR TITLE
Add missing include on cstdint to database_impl.hpp

### DIFF
--- a/src/djinterop/impl/database_impl.hpp
+++ b/src/djinterop/impl/database_impl.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
It won't build on Musl without it due to not knowing about int64_t

Supersedes #122 