### PR TITLE
Doxygen: Build documentation and host on GitHub Pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3.0.1
         with:
-          path: docs
+          path: ${{github.workspace}}/build/docs
 
       - name: Deploy artifact
         uses: actions/deploy-pages@v4

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  documenation:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Doxygen
+        run: sudo apt-get install -y doxygen graphviz
+
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-12 -DCMAKE_CXX_COMPILER=g++-12
+
+      - name: Generate Documentation
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build --config Debug --target docs
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: docs
+
+      - name: Deploy artifact
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ compile_commands.json
 # CMake typical build dirs
 /cmake_build*
 /cmake-build*
+
+# Doxygen
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ compile_commands.json
 # CMake typical build dirs
 /cmake_build*
 /cmake-build*
-
-# Doxygen
-docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,3 +285,25 @@ endif()
 include(InstallRequiredSystemLibraries)
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 include(CPack)
+
+# Add documentation option
+option(BUILD_DOC "Build documentation" ON)
+
+# Check if Doxygen is installed
+find_package(Doxygen OPTIONAL_COMPONENTS dot dia)
+if (DOXYGEN_FOUND)
+    set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set(DOXYGEN_HTML_OUTPUT docs)
+    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE README.md)
+
+    message("Doxygen build started")
+
+    doxygen_add_docs(
+            docs
+            include
+            README.md
+            COMMENT "Generate docs"
+    )
+else (DOXYGEN_FOUND)
+    message("Doxygen need to be installed to generate the doxygen documentation")
+endif (DOXYGEN_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,6 @@ option(BUILD_DOC "Build documentation" ON)
 # Check if Doxygen is installed
 find_package(Doxygen OPTIONAL_COMPONENTS dot dia)
 if (DOXYGEN_FOUND)
-    set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set(DOXYGEN_HTML_OUTPUT docs)
     set(DOXYGEN_USE_MDFILE_AS_MAINPAGE README.md)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This library currently supports:
 
 * Engine Library, as used on "Prime"-series DJ equipment.
 
+Documentation can be viewed on [GitHub Pages](https://xcso.github.io/libdjinterop/)
+
 State of Support
 ================
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library currently supports:
 
 * Engine Library, as used on "Prime"-series DJ equipment.
 
-Documentation can be viewed on [GitHub Pages](https://xcso.github.io/libdjinterop/)
+Documentation can be viewed on [GitHub Pages](https://xsco.github.io/libdjinterop/)
 
 State of Support
 ================


### PR DESCRIPTION
Before you merge this in, you'll have to go to the repository's pages settings, and enable pages from GitHub Actions, otherwise the action will fail with an error about pages not being enabled.

Closes: #68