### PR TITLE
Separate Engine Database2/schema concepts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(libdjinterop
-        VERSION 0.23.0
+        VERSION 0.23.1
         DESCRIPTION "C++ library providing access to DJ record libraries")
 set(PROJECT_HOMEPAGE_URL "https://github.com/xsco/libdjinterop")
 
@@ -42,8 +42,10 @@ add_library(
     src/djinterop/impl/crate_impl.cpp
     src/djinterop/impl/database_impl.cpp
     src/djinterop/impl/track_impl.cpp
+    src/djinterop/engine/base_engine_library.cpp
     src/djinterop/engine/encode_decode_utils.cpp
     src/djinterop/engine/engine.cpp
+    src/djinterop/engine/engine_library_dir_utils.cpp
     src/djinterop/engine/schema/schema_1_6_0.cpp
     src/djinterop/engine/schema/schema_1_7_1.cpp
     src/djinterop/engine/schema/schema_1_9_1.cpp

--- a/example/engine_library_v2_low_level.cpp
+++ b/example/engine_library_v2_low_level.cpp
@@ -32,7 +32,7 @@ int main()
     auto dir = "Engine Library";
     auto exists = ev2::engine_library::exists(dir);
     auto library = exists
-                       ? ev2::engine_library{dir}
+                       ? ev2::engine_library::load(dir)
                        : ev2::engine_library::create(dir, e::latest_v2_schema);
 
     std::cout << (exists ? "Loaded" : "Created")

--- a/include/djinterop/engine/base_engine_library.hpp
+++ b/include/djinterop/engine/base_engine_library.hpp
@@ -1,0 +1,81 @@
+/*
+    This file is part of libdjinterop.
+
+    libdjinterop is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libdjinterop is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if __cplusplus < 201703L
+#error This library needs at least a C++17 compliant compiler
+#endif
+
+#include <memory>
+#include <string>
+
+#include <djinterop/config.hpp>
+#include <djinterop/database.hpp>
+#include <djinterop/engine/engine_schema.hpp>
+
+namespace djinterop::engine
+{
+struct engine_library_context;
+
+/// Abstract base class for an Engine Library.
+///
+class DJINTEROP_PUBLIC base_engine_library
+{
+public:
+    /// Construct an instance of the class using an Engine library context.
+    ///
+    /// \param context Engine library context.
+    explicit base_engine_library(
+        std::shared_ptr<engine_library_context> context);
+
+    virtual ~base_engine_library() = default;
+
+    /// Verify the correctness of the Engine library database schema for its
+    /// stated version.
+    void verify() const;
+
+    /// Get the Engine library top-level directory.
+    ///
+    /// \return Returns the top-level directory.
+    [[nodiscard]] std::string directory() const;
+
+    /// Get the schema version of the Engine library.
+    ///
+    /// \return Returns the Engine schema version.
+    [[nodiscard]] engine_schema schema() const;
+
+    /// Get the unified database interface for this Engine library.
+    [[nodiscard]] virtual djinterop::database database() const = 0;
+
+protected:
+    static std::shared_ptr<engine_library_context> load(
+        const std::string& directory);
+
+    static std::shared_ptr<engine_library_context> create(
+        const std::string& directory, const engine_schema& schema);
+
+    static std::shared_ptr<engine_library_context> create_temporary(
+        const engine_schema& schema);
+
+    static bool exists(const std::string& directory);
+
+    // Pimpl-like idiom, also used by other classes.
+    std::shared_ptr<engine_library_context> context_;
+};
+
+}  // namespace djinterop::engine

--- a/include/djinterop/engine/engine_schema.hpp
+++ b/include/djinterop/engine/engine_schema.hpp
@@ -67,7 +67,7 @@ constexpr std::array<engine_schema, 18> supported_schemas{
     engine_schema::schema_2_20_3,    engine_schema::schema_2_21_0,
     engine_schema::schema_2_21_1,    engine_schema::schema_2_21_2};
 
-/// Set of supported legacy schema versions.
+/// Set of supported schema 1.x versions.
 constexpr std::array<engine_schema, 11> supported_v1_schemas{
     engine_schema::schema_1_6_0,    engine_schema::schema_1_7_1,
     engine_schema::schema_1_9_1,    engine_schema::schema_1_11_1,
@@ -76,7 +76,7 @@ constexpr std::array<engine_schema, 11> supported_v1_schemas{
     engine_schema::schema_1_17_0,   engine_schema::schema_1_18_0_desktop,
     engine_schema::schema_1_18_0_os};
 
-/// Set of supported "Database2" schema versions.
+/// Set of supported schema 2.x versions.
 constexpr std::array<engine_schema, 7> supported_v2_schemas{
     engine_schema::schema_2_18_0, engine_schema::schema_2_20_1,
     engine_schema::schema_2_20_2, engine_schema::schema_2_20_3,
@@ -86,10 +86,10 @@ constexpr std::array<engine_schema, 7> supported_v2_schemas{
 /// The most recent schema version supported by the library.
 constexpr engine_schema latest_schema = engine_schema::schema_2_21_2;
 
-/// The most recent legacy schema version supported by the library.
+/// The most recent schema 1.x version supported by the library.
 constexpr engine_schema latest_v1_schema = engine_schema::schema_1_18_0_os;
 
-/// The most recent "Database2" schema version supported by the library.
+/// The most recent schema 2.x version supported by the library.
 constexpr engine_schema latest_v2_schema = engine_schema::schema_2_21_2;
 
 /// Get a string representation of the schema.

--- a/include/djinterop/engine/v2/change_log_table.hpp
+++ b/include/djinterop/engine/v2/change_log_table.hpp
@@ -28,9 +28,13 @@
 
 #include <djinterop/config.hpp>
 
-namespace djinterop::engine::v2
+namespace djinterop::engine
 {
 struct engine_library_context;
+}
+
+namespace djinterop::engine::v2
+{
 
 /// Represents a single row in the `ChangeLog` table.
 ///

--- a/include/djinterop/engine/v2/information_table.hpp
+++ b/include/djinterop/engine/v2/information_table.hpp
@@ -27,9 +27,13 @@
 
 #include <djinterop/config.hpp>
 
-namespace djinterop::engine::v2
+namespace djinterop::engine
 {
 struct engine_library_context;
+}
+
+namespace djinterop::engine::v2
+{
 
 /// Represents the single-row contents of the `Information` table.
 struct DJINTEROP_PUBLIC information_row

--- a/include/djinterop/engine/v2/playlist_entity_table.hpp
+++ b/include/djinterop/engine/v2/playlist_entity_table.hpp
@@ -31,9 +31,13 @@
 
 #include <djinterop/config.hpp>
 
-namespace djinterop::engine::v2
+namespace djinterop::engine
 {
 struct engine_library_context;
+}
+
+namespace djinterop::engine::v2
+{
 
 /// Thrown when the id on a playlist entity row is in an erroneous state for a
 /// given operation.

--- a/include/djinterop/engine/v2/playlist_table.hpp
+++ b/include/djinterop/engine/v2/playlist_table.hpp
@@ -34,9 +34,13 @@
 #include <djinterop/config.hpp>
 #include <djinterop/stream_helper.hpp>
 
-namespace djinterop::engine::v2
+namespace djinterop::engine
 {
 struct engine_library_context;
+}
+
+namespace djinterop::engine::v2
+{
 
 /// Thrown when the id on a playlist row is in an erroneous state for a given
 /// operation.

--- a/include/djinterop/engine/v2/track_table.hpp
+++ b/include/djinterop/engine/v2/track_table.hpp
@@ -37,9 +37,13 @@
 #include <djinterop/engine/v2/track_data_blob.hpp>
 #include <djinterop/stream_helper.hpp>
 
-namespace djinterop::engine::v2
+namespace djinterop::engine
 {
 struct engine_library_context;
+}
+
+namespace djinterop::engine::v2
+{
 
 /// Thrown when the id on a track row is in an erroneous state for a given
 /// operation.
@@ -545,8 +549,7 @@ public:
     std::optional<std::string> get_album_art(int64_t id);
 
     /// Set the `albumArt` column for a given track.
-    void set_album_art(
-        int64_t id, const std::optional<std::string>& album_art);
+    void set_album_art(int64_t id, const std::optional<std::string>& album_art);
 
     /// Get the `timeLastPlayed` column for a given track.
     std::optional<std::chrono::system_clock::time_point> get_time_last_played(
@@ -598,8 +601,8 @@ public:
     /// Set the `dateAdded` column for a given track, representing the time at
     /// which the track was added to the database.
     void set_date_added(
-        int64_t id, const std::optional<std::chrono::system_clock::time_point>&
-                        date_added);
+        int64_t id,
+        const std::optional<std::chrono::system_clock::time_point>& date_added);
 
     /// Get the `isAvailable` column for a given track, indicating if the file
     /// underlying the track entry is available.

--- a/src/djinterop/engine/base_engine_library.cpp
+++ b/src/djinterop/engine/base_engine_library.cpp
@@ -1,0 +1,94 @@
+/*
+    This file is part of libdjinterop.
+
+    libdjinterop is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libdjinterop is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <djinterop/engine/base_engine_library.hpp>
+
+#include <sqlite_modern_cpp.h>
+
+#include <djinterop/engine/engine.hpp>
+#include <memory>
+#include <utility>
+
+#include "engine_library_context.hpp"
+#include "engine_library_dir_utils.hpp"
+#include "schema/schema.hpp"
+
+namespace djinterop::engine
+{
+base_engine_library::base_engine_library(
+    std::shared_ptr<engine_library_context> context) :
+    context_{std::move(context)}
+{
+}
+
+std::shared_ptr<engine_library_context> base_engine_library::load(
+    const std::string& directory)
+{
+    auto db = load_database2_sqlite_database(directory);
+
+    const auto schema = schema::detect_schema(db);
+    return std::make_shared<engine_library_context>(
+        directory, true, schema, db);
+}
+
+std::shared_ptr<engine_library_context> base_engine_library::create(
+    const std::string& directory, const engine_schema& schema)
+{
+    auto db = create_database2_sqlite_database(directory);
+
+    auto schema_creator = schema::make_schema_creator_validator(schema);
+    schema_creator->create(db);
+
+    return std::make_shared<engine_library_context>(
+        directory, true, schema, std::move(db));
+}
+
+std::shared_ptr<engine_library_context> base_engine_library::create_temporary(
+    const engine_schema& schema)
+{
+    auto db = create_temporary_database2_sqlite_database();
+
+    // Create the desired schema on the new database.
+    auto schema_creator = schema::make_schema_creator_validator(schema);
+    schema_creator->create(db);
+
+    return std::make_shared<engine_library_context>(
+        ":memory:", true, schema, std::move(db));
+}
+
+bool base_engine_library::exists(const std::string& directory)
+{
+    return database2_database_exists(directory);
+}
+
+void base_engine_library::verify() const
+{
+    auto validator = schema::make_schema_creator_validator(context_->schema);
+    validator->verify(context_->db);
+}
+
+std::string base_engine_library::directory() const
+{
+    return context_->directory;
+}
+
+engine_schema base_engine_library::schema() const
+{
+    return context_->schema;
+}
+
+}  // namespace djinterop::engine

--- a/src/djinterop/engine/engine_library_context.hpp
+++ b/src/djinterop/engine/engine_library_context.hpp
@@ -1,0 +1,55 @@
+/*
+    This file is part of libdjinterop.
+
+    libdjinterop is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libdjinterop is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <sqlite_modern_cpp.h>
+
+#include <djinterop/engine/engine_schema.hpp>
+
+namespace djinterop::engine
+{
+struct engine_library_context
+{
+    engine_library_context(
+        std::string directory, bool is_database2, engine_schema schema,
+        sqlite::database db) :
+        directory{std::move(directory)}, is_database2{is_database2},
+        schema{schema}, db{std::move(db)}
+    {
+    }
+
+    /// The directory in which the Engine DB files reside.
+    const std::string directory;
+
+    /// Flag indicating whether the directory is of the 'Database2' structure.
+    ///
+    /// A 'Database2' library has the SQLite database files under a
+    /// subdirectory named `Database2`.  A legacy-type library has the SQLite
+    /// database files immediately under the main directory.
+    const bool is_database2;
+
+    /// The schema version of the Engine database.
+    const engine_schema schema;
+
+    /// The main SQLite database holding Engine data.
+    sqlite::database db;
+};
+
+}  // namespace djinterop::engine

--- a/src/djinterop/engine/engine_library_dir_utils.cpp
+++ b/src/djinterop/engine/engine_library_dir_utils.cpp
@@ -1,0 +1,168 @@
+/*
+    This file is part of libdjinterop.
+
+    libdjinterop is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libdjinterop is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with libdjinterop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "engine_library_dir_utils.hpp"
+
+#include <djinterop/exceptions.hpp>
+
+#include "../util/filesystem.hpp"
+
+namespace djinterop::engine
+{
+namespace
+{
+std::string make_legacy_m_db_path(const std::string& directory)
+{
+    return directory + "/m.db";
+}
+
+std::string make_legacy_p_db_path(const std::string& directory)
+{
+    return directory + "/p.db";
+}
+
+std::string make_database2_db_dir_path(const std::string& directory)
+{
+    return directory + "/Database2";
+}
+
+std::string make_database2_m_db_path(const std::string& directory)
+{
+    return directory + "/Database2/m.db";
+}
+}  // namespace
+
+bool detect_is_database2(const std::string& directory)
+{
+    if (!djinterop::util::path_exists(directory))
+    {
+        throw database_not_found{directory};
+    }
+
+    // Assume that all versions of engine libraries have a database called
+    // "m.db", containing a table called "Information", containing the schema
+    // version in some of its columns.
+    auto legacy_m_db_path = directory + "/m.db";
+    auto database2_m_db_path = directory + "/Database2/m.db";
+    auto legacy_m_db_path_exists =
+        djinterop::util::path_exists(legacy_m_db_path);
+    auto database2_m_db_path_exists =
+        djinterop::util::path_exists(database2_m_db_path);
+
+    if (!legacy_m_db_path_exists && !database2_m_db_path_exists)
+    {
+        throw database_not_found{"Neither m.db nor Database2/m.db was found"};
+    }
+
+    if (legacy_m_db_path_exists && database2_m_db_path_exists)
+    {
+        throw database_not_found{
+            "Found m.db and Database2/m.db files, which is not supposed to "
+            "happen"};
+    }
+
+    return database2_m_db_path_exists;
+}
+
+sqlite::database create_legacy_sqlite_database(const std::string& directory)
+{
+    if (!djinterop::util::path_exists(directory))
+    {
+        // Note: only creates leaf directory, not entire tree.
+        djinterop::util::create_dir(directory);
+    }
+
+    sqlite::database db{":memory:"};
+    db << "ATTACH ? as 'music'" << make_legacy_m_db_path(directory);
+    db << "ATTACH ? as 'perfdata'" << make_legacy_p_db_path(directory);
+    return db;
+}
+
+sqlite::database create_database2_sqlite_database(const std::string& directory)
+{
+    // Ensure the target directory exists.
+    if (!djinterop::util::path_exists(directory))
+    {
+        djinterop::util::create_dir(directory);
+    }
+
+    auto db_dir_path = make_database2_db_dir_path(directory);
+    if (!djinterop::util::path_exists(db_dir_path))
+    {
+        djinterop::util::create_dir(db_dir_path);
+    }
+
+    // Target database must not exist.
+    auto db_path = make_database2_m_db_path(directory);
+    if (djinterop::util::path_exists(db_path))
+    {
+        throw database_inconsistency{
+            "Cannot create new Engine library, as the database file already "
+            "exists"};
+    }
+
+    return sqlite::database{db_path};
+}
+
+sqlite::database create_temporary_legacy_sqlite_database()
+{
+    sqlite::database db{":memory:"};
+    db << "ATTACH ':memory:' as 'music'";
+    db << "ATTACH ':memory:' as 'perfdata'";
+    return db;
+}
+
+sqlite::database create_temporary_database2_sqlite_database()
+{
+    return sqlite::database{":memory:"};
+}
+
+sqlite::database load_legacy_sqlite_database(const std::string& directory)
+{
+    if (!djinterop::util::path_exists(directory))
+    {
+        throw database_not_found{directory};
+    }
+
+    sqlite::database db{":memory:"};
+    db << "ATTACH ? as 'music'" << (directory + "/m.db");
+    db << "ATTACH ? as 'perfdata'" << (directory + "/p.db");
+    return db;
+}
+
+sqlite::database load_database2_sqlite_database(const std::string& directory)
+{
+    auto db_path = make_database2_m_db_path(directory);
+    if (!djinterop::util::path_exists(db_path))
+    {
+        throw database_not_found{directory};
+    }
+
+    return sqlite::database{db_path};
+}
+
+bool legacy_database_exists(const std::string& directory)
+{
+    return djinterop::util::path_exists(make_legacy_m_db_path(directory));
+}
+
+bool database2_database_exists(const std::string& directory)
+{
+    return djinterop::util::path_exists(make_database2_m_db_path(directory));
+}
+
+}  // namespace djinterop::engine

--- a/src/djinterop/engine/engine_library_dir_utils.hpp
+++ b/src/djinterop/engine/engine_library_dir_utils.hpp
@@ -21,26 +21,24 @@
 
 #include <sqlite_modern_cpp.h>
 
-#include <djinterop/engine/engine_schema.hpp>
-
-namespace djinterop::engine::v2
+namespace djinterop::engine
 {
-struct engine_library_context
-{
-    engine_library_context(
-        std::string directory, engine_schema schema, sqlite::database db) :
-        directory{std::move(directory)}, schema{schema}, db{std::move(db)}
-    {
-    }
+bool detect_is_database2(const std::string& directory);
 
-    /// The directory in which the Engine DB files reside.
-    const std::string directory;
+sqlite::database create_legacy_sqlite_database(const std::string& directory);
 
-    /// The schema version of the Engine database.
-    const engine_schema schema;
+sqlite::database create_database2_sqlite_database(const std::string& directory);
 
-    /// The main SQLite database holding Engine data.
-    sqlite::database db;
-};
+sqlite::database create_temporary_legacy_sqlite_database();
 
-}  // namespace djinterop::engine::v2
+sqlite::database create_temporary_database2_sqlite_database();
+
+sqlite::database load_legacy_sqlite_database(const std::string& directory);
+
+sqlite::database load_database2_sqlite_database(const std::string& directory);
+
+bool legacy_database_exists(const std::string& directory);
+
+bool database2_database_exists(const std::string& directory);
+
+}  // namespace djinterop::engine

--- a/src/djinterop/engine/schema/schema_3_0_0.cpp
+++ b/src/djinterop/engine/schema/schema_3_0_0.cpp
@@ -359,9 +359,6 @@ void schema_3_0_0::create(sqlite::database& db)
           "INTEGER, 	schemaVersionPatch INTEGER, 	"
           "currentPlayedIndiciator INTEGER, 	"
           "lastRekordBoxLibraryImportReadCounter INTEGER);";
-    db << "INSERT INTO Information "
-          "VALUES(1,'43b432fc-8c09-40cd-8ef4-9fcb9a853f84',3,0,0,"
-          "8054931482920806910,NULL);";
     db << "CREATE TABLE AlbumArt ( 	id INTEGER PRIMARY KEY AUTOINCREMENT, 	"
           "hash TEXT, 	albumArt BLOB );";
     db << "CREATE TABLE Pack ( 	id INTEGER PRIMARY KEY AUTOINCREMENT, 	packId "
@@ -413,7 +410,6 @@ void schema_3_0_0::create(sqlite::database& db)
           "AUTOINCREMENT, 	trackId INTEGER, 	trackNumber INTEGER, 	"
           "FOREIGN KEY (trackId) REFERENCES Track (id) ON DELETE CASCADE );";
     db << "DELETE FROM sqlite_sequence;";
-    db << "INSERT INTO sqlite_sequence VALUES('Information',1);";
     db << "CREATE INDEX index_AlbumArt_hash ON AlbumArt (hash);";
     db << "CREATE INDEX index_PlaylistEntity_nextEntityId_listId ON "
           "PlaylistEntity(nextEntityId, listId);";

--- a/src/djinterop/engine/v2/change_log_table.cpp
+++ b/src/djinterop/engine/v2/change_log_table.cpp
@@ -22,7 +22,7 @@
 
 #include <djinterop/exceptions.hpp>
 
-#include "engine_library_context.hpp"
+#include "../engine_library_context.hpp"
 
 namespace djinterop::engine::v2
 {

--- a/src/djinterop/engine/v2/engine_library.cpp
+++ b/src/djinterop/engine/v2/engine_library.cpp
@@ -17,132 +17,19 @@
 
 #include <djinterop/engine/v2/engine_library.hpp>
 
-#include <sqlite_modern_cpp.h>
-
-#include <djinterop/engine/engine.hpp>
-#include <djinterop/exceptions.hpp>
 #include <memory>
-#include <utility>
 
-#include "../../util/filesystem.hpp"
-#include "../schema/schema.hpp"
+#include <djinterop/database.hpp>
+
 #include "database_impl.hpp"
-#include "engine_library_context.hpp"
 
 namespace djinterop::engine::v2
 {
-namespace
-{
-inline std::string make_db_dir_path(const std::string& directory)
-{
-    return directory + "/Database2";
-}
-
-inline std::string make_db_path(const std::string& directory)
-{
-    return directory + "/Database2/m.db";
-}
-
-std::shared_ptr<engine_library_context> load_existing(
-    const std::string& directory)
-{
-    auto db_path = make_db_path(directory);
-    if (!djinterop::util::path_exists(db_path))
-    {
-        throw database_not_found{directory};
-    }
-
-    sqlite::database db{db_path};
-
-    const auto schema = schema::detect_schema(db);
-    return std::make_shared<engine_library_context>(directory, schema, db);
-}
-
-}  // anonymous namespace
-
-engine_library::engine_library(const std::string& directory) :
-    engine_library{load_existing(directory)}
-{
-}
-
-engine_library::engine_library(
-    std::shared_ptr<engine_library_context> context) :
-    context_{std::move(context)}
-{
-}
-
-engine_library engine_library::create(
-    const std::string& directory, const engine_schema& schema)
-{
-    // Ensure the target directory exists.
-    if (!djinterop::util::path_exists(directory))
-    {
-        djinterop::util::create_dir(directory);
-    }
-
-    auto db_dir_path = make_db_dir_path(directory);
-    if (!djinterop::util::path_exists(db_dir_path))
-    {
-        djinterop::util::create_dir(db_dir_path);
-    }
-
-    // Target database must not exist.
-    auto db_path = make_db_path(directory);
-    if (djinterop::util::path_exists(db_path))
-    {
-        throw database_inconsistency{
-            "Cannot create new Engine library, as the database file already "
-            "exists"};
-    }
-
-    auto db = sqlite::database{db_path};
-
-    auto schema_creator = schema::make_schema_creator_validator(schema);
-    schema_creator->create(db);
-
-    return engine_library{std::make_shared<engine_library_context>(
-        directory, schema, std::move(db))};
-}
-
-engine_library engine_library::create_temporary(const engine_schema& schema)
-{
-    auto db = sqlite::database(":memory:");
-
-    // Create the desired schema on the new database.
-    auto schema_creator = schema::make_schema_creator_validator(schema);
-    schema_creator->create(db);
-
-    return engine_library{std::make_shared<engine_library_context>(
-        ":memory:", schema, std::move(db))};
-}
-
-bool engine_library::exists(const std::string& directory)
-{
-    return djinterop::util::path_exists(make_db_path(directory));
-}
-
-void engine_library::verify() const
-{
-    auto validator =
-        schema::make_schema_creator_validator(context_->schema);
-    validator->verify(context_->db);
-}
-
 database engine_library::database() const
 {
     auto library = std::make_shared<engine_library>(*this);
     auto pimpl = std::make_shared<database_impl>(library);
     return djinterop::database{pimpl};
-}
-
-std::string engine_library::directory() const
-{
-    return context_->directory;
-}
-
-engine_schema engine_library::schema() const
-{
-    return context_->schema;
 }
 
 }  // namespace djinterop::engine::v2

--- a/src/djinterop/engine/v2/information_table.cpp
+++ b/src/djinterop/engine/v2/information_table.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <utility>
 
-#include "engine_library_context.hpp"
+#include "../engine_library_context.hpp"
 
 namespace djinterop::engine::v2
 {

--- a/src/djinterop/engine/v2/playlist_entity_table.cpp
+++ b/src/djinterop/engine/v2/playlist_entity_table.cpp
@@ -22,7 +22,7 @@
 #include <utility>
 
 #include "../../util/sqlite_transaction.hpp"
-#include "engine_library_context.hpp"
+#include "../engine_library_context.hpp"
 
 namespace djinterop::engine::v2
 {

--- a/src/djinterop/engine/v2/playlist_table.cpp
+++ b/src/djinterop/engine/v2/playlist_table.cpp
@@ -25,7 +25,7 @@
 
 #include "../../util/chrono.hpp"
 #include "../../util/sqlite_transaction.hpp"
-#include "engine_library_context.hpp"
+#include "../engine_library_context.hpp"
 
 namespace djinterop::engine::v2
 {

--- a/src/djinterop/engine/v2/track_table.cpp
+++ b/src/djinterop/engine/v2/track_table.cpp
@@ -21,11 +21,11 @@
 #include <cstddef>
 #include <utility>
 
-#include <djinterop/engine/v2/engine_library_context.hpp>
 #include <djinterop/exceptions.hpp>
 
 #include "../../util/chrono.hpp"
 #include "../../util/convert.hpp"
+#include "../engine_library_context.hpp"
 
 namespace djinterop::engine::v2
 {


### PR DESCRIPTION
Separate the concepts of the Database2 directory structure, and Engine schema.  This will allow easier introduction of new schemas (e.g. 3.x) that happen to share the same "Database2"-type directory structure.

Allow extracted some common Engine Library functions into a base class, visible in the public API but not directly used by the end developer, to make forthcoming introduction of schema 3.x easier.

Relates to #129.