### PR TITLE
Increase C++ standard to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ if(POLICY CMP0076)
     cmake_policy(SET CMP0076 NEW)
 endif()
 
-# Require C++17
-set(CMAKE_CXX_STANDARD 17)
+# Require C++20
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 if(MSVC)
     add_compile_options("/W4" "/wd4251" "/wd4275" "$<$<CONFIG:RELEASE>:/O2>")


### PR DESCRIPTION
With C++17 I get:
`djinterop\engine\v2\beat_data_blob.cpp(94): error C7555: use of designated initializers requires at least '/std:c++20'`