### PR TITLE
Fix uninitialised var in Engine waveform code

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: RelWithDebinfo
 
 jobs:
   build:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(libdjinterop
-        VERSION 0.24.1
+        VERSION 0.24.2
         DESCRIPTION "C++ library providing access to DJ record libraries")
 set(PROJECT_HOMEPAGE_URL "https://github.com/xsco/libdjinterop")
 

--- a/src/djinterop/engine/v1/engine_track_impl.cpp
+++ b/src/djinterop/engine/v1/engine_track_impl.cpp
@@ -1095,6 +1095,11 @@ void engine_track_impl::set_waveform(std::vector<waveform_entry> waveform)
             high_res_extents.samples_per_entry;
         high_res_waveform_d.waveform = std::move(waveform);
     }
+    else
+    {
+        overview_waveform_d.samples_per_entry = 0;
+        high_res_waveform_d.samples_per_entry = 0;
+    }
 
     set_overview_waveform_data(std::move(overview_waveform_d));
     set_high_res_waveform_data(std::move(high_res_waveform_d));

--- a/src/djinterop/engine/v2/convert_waveform.hpp
+++ b/src/djinterop/engine/v2/convert_waveform.hpp
@@ -65,16 +65,21 @@ inline overview_waveform_data_blob waveform(
     std::optional<unsigned long long> sample_count,
     std::optional<double> sample_rate)
 {
-    overview_waveform_data_blob result;
     if (w.empty())
     {
-        result.maximum_point = overview_waveform_point{0, 0, 0};
-        return result;
+        return overview_waveform_data_blob
+        {
+            .samples_per_waveform_point = 0,
+            .waveform_points = {},
+            .maximum_point = {0, 0, 0},
+            .extra_data = {},
+        };
     }
 
     auto extents =
         util::calculate_overview_waveform_extents(*sample_count, *sample_rate);
 
+    overview_waveform_data_blob result;
     result.samples_per_waveform_point = extents.samples_per_entry;
 
     uint8_t max_low = 0;


### PR DESCRIPTION
The `-Wmaybe-uninitialized` needs optimisations to work, so changing CI runners to `RelWithDebInfo` by default.