### PR TITLE
Remove deprecated crate/playlist methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(libdjinterop
-        VERSION 0.25.0
+        VERSION 0.26.0
         DESCRIPTION "C++ library providing access to DJ record libraries")
 set(PROJECT_HOMEPAGE_URL "https://github.com/xsco/libdjinterop")
 

--- a/example/engine_prime.cpp
+++ b/example/engine_prime.cpp
@@ -40,7 +40,7 @@ int main()
         db.remove_playlist(pl);
     }
 
-    for (auto& cr : db.crates())
+    for (auto& cr : db.root_crates())
     {
         std::cout << "Removing prior crate " << cr.name() << std::endl;
         db.remove_crate(cr);

--- a/include/djinterop/database.hpp
+++ b/include/djinterop/database.hpp
@@ -79,12 +79,6 @@ public:
     /// is returned.
     std::optional<crate> crate_by_id(int64_t id) const;
 
-    /// Returns all crates contained in the database
-    std::vector<crate> crates() const;
-
-    /// Returns all crates with the given name
-    std::vector<crate> crates_by_name(const std::string& name) const;
-
     /// Create a new playlist with the given name.
     playlist create_root_playlist(const std::string& name);
 
@@ -117,9 +111,6 @@ public:
 
     /// Returns a descriptive name for the database version.
     std::string version_name() const;
-
-    /// Returns the playlists with the given name.
-    std::vector<playlist> playlists_by_name(const std::string& name) const;
 
     /// Removes a crate from the database
     ///

--- a/src/djinterop/database.cpp
+++ b/src/djinterop/database.cpp
@@ -41,16 +41,6 @@ std::optional<crate> database::crate_by_id(int64_t id) const
     return pimpl_->crate_by_id(id);
 }
 
-std::vector<crate> database::crates() const
-{
-    return pimpl_->crates();
-}
-
-std::vector<crate> database::crates_by_name(const std::string& name) const
-{
-    return pimpl_->crates_by_name(name);
-}
-
 playlist database::create_root_playlist(const std::string& name)
 {
     return pimpl_->create_root_playlist(name);
@@ -84,11 +74,6 @@ std::string database::directory() const
 void database::verify() const
 {
     pimpl_->verify();
-}
-
-std::vector<playlist> database::playlists_by_name(const std::string& name) const
-{
-    return pimpl_->playlists_by_name(name);
 }
 
 void database::remove_crate(crate cr) const

--- a/src/djinterop/engine/v1/engine_database_impl.cpp
+++ b/src/djinterop/engine/v1/engine_database_impl.cpp
@@ -90,27 +90,6 @@ std::optional<crate> engine_database_impl::crate_by_id(int64_t id)
     return cr;
 }
 
-std::vector<crate> engine_database_impl::crates()
-{
-    std::vector<crate> results;
-    storage_->db << "SELECT id FROM Crate ORDER BY id" >> [&](int64_t id) {
-        results.push_back(crate{std::make_shared<engine_crate_impl>(storage_, id)});
-    };
-    return results;
-}
-
-std::vector<crate> engine_database_impl::crates_by_name(const std::string& name)
-{
-    std::vector<crate> results;
-    storage_->db << "SELECT id FROM Crate WHERE title = ? ORDER BY id"
-                 << name.data() >>
-        [&](int64_t id) {
-            results.push_back(
-                crate{std::make_shared<engine_crate_impl>(storage_, id)});
-        };
-    return results;
-}
-
 crate engine_database_impl::create_root_crate(const std::string& name)
 {
     ensure_valid_crate_name(name);
@@ -208,22 +187,6 @@ void engine_database_impl::verify()
     auto schema_creator_validator =
         schema::make_schema_creator_validator(storage_->schema);
     schema_creator_validator->verify(storage_->db);
-}
-
-std::vector<playlist> engine_database_impl::playlists_by_name(const std::string& name)
-{
-    // Engine V1 only supports root-level playlists.
-    std::vector<playlist> results;
-    if (const auto result = root_playlist_by_name(name))
-        results.push_back(result.value());
-
-    return results;
-}
-
-std::vector<playlist> engine_database_impl::playlists()
-{
-    // Engine V1 only supports root-level playlists.
-    return root_playlists();
 }
 
 void engine_database_impl::remove_crate(crate cr)

--- a/src/djinterop/engine/v1/engine_database_impl.hpp
+++ b/src/djinterop/engine/v1/engine_database_impl.hpp
@@ -30,9 +30,6 @@ public:
     engine_database_impl(std::shared_ptr<engine_storage> storage);
 
     std::optional<djinterop::crate> crate_by_id(int64_t id) override;
-    std::vector<djinterop::crate> crates() override;
-    std::vector<djinterop::crate> crates_by_name(
-        const std::string& name) override;
     crate create_root_crate(const std::string& name) override;
     crate create_root_crate_after(
         const std::string& name, const crate& after) override;
@@ -42,8 +39,6 @@ public:
     track create_track(const track_snapshot& snapshot) override;
     std::string directory() override;
     void verify() override;
-    std::vector<playlist> playlists_by_name(const std::string& name) override;
-    std::vector<playlist> playlists() override;
     void remove_crate(djinterop::crate cr) override;
     void remove_playlist(const djinterop::playlist_impl& pl_base) override;
     void remove_track(djinterop::track tr) override;

--- a/src/djinterop/engine/v2/database_impl.cpp
+++ b/src/djinterop/engine/v2/database_impl.cpp
@@ -46,34 +46,6 @@ std::optional<crate> database_impl::crate_by_id(int64_t id)
     return std::make_optional<crate>(crate{impl});
 }
 
-std::vector<crate> database_impl::crates()
-{
-    auto ids = library_->playlist().all_ids();
-    std::vector<crate> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<crate_impl>(library_, id));
-    }
-
-    return results;
-}
-
-std::vector<crate> database_impl::crates_by_name(const std::string& name)
-{
-    auto ids = library_->playlist().find_ids(name);
-    std::vector<crate> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<crate_impl>(library_, id));
-    }
-
-    return results;
-}
-
 playlist database_impl::create_root_playlist(const std::string& name)
 {
     if (library_->playlist().find_root_id(name))
@@ -199,34 +171,6 @@ std::string database_impl::directory()
 void database_impl::verify()
 {
     library_->verify();
-}
-
-std::vector<playlist> database_impl::playlists()
-{
-    auto ids = library_->playlist().all_ids();
-    std::vector<playlist> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<playlist_impl>(library_, id));
-    }
-
-    return results;
-}
-
-std::vector<playlist> database_impl::playlists_by_name(const std::string& name)
-{
-    auto ids = library_->playlist().find_ids(name);
-    std::vector<playlist> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<playlist_impl>(library_, id));
-    }
-
-    return results;
 }
 
 void database_impl::remove_crate(crate cr)

--- a/src/djinterop/engine/v2/database_impl.hpp
+++ b/src/djinterop/engine/v2/database_impl.hpp
@@ -33,9 +33,6 @@ public:
     explicit database_impl(std::shared_ptr<engine_library> library);
 
     std::optional<djinterop::crate> crate_by_id(int64_t id) override;
-    std::vector<djinterop::crate> crates() override;
-    std::vector<djinterop::crate> crates_by_name(
-        const std::string& name) override;
     crate create_root_crate(const std::string& name) override;
     crate create_root_crate_after(
         const std::string& name, const crate& after) override;
@@ -46,8 +43,6 @@ public:
     track create_track(const track_snapshot& snapshot) override;
     std::string directory() override;
     void verify() override;
-    std::vector<playlist> playlists_by_name(const std::string& name) override;
-    std::vector<playlist> playlists() override;
     void remove_crate(djinterop::crate cr) override;
     void remove_playlist(const djinterop::playlist_impl& pl_base) override;
     void remove_track(djinterop::track tr) override;

--- a/src/djinterop/engine/v3/database_impl.cpp
+++ b/src/djinterop/engine/v3/database_impl.cpp
@@ -46,34 +46,6 @@ std::optional<crate> database_impl::crate_by_id(int64_t id)
     return std::make_optional<crate>(crate{impl});
 }
 
-std::vector<crate> database_impl::crates()
-{
-    auto ids = library_->playlist().all_ids();
-    std::vector<crate> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<crate_impl>(library_, id));
-    }
-
-    return results;
-}
-
-std::vector<crate> database_impl::crates_by_name(const std::string& name)
-{
-    auto ids = library_->playlist().find_ids(name);
-    std::vector<crate> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<crate_impl>(library_, id));
-    }
-
-    return results;
-}
-
 crate database_impl::create_root_crate(const std::string& name)
 {
     if (library_->playlist().find_root_id(name))
@@ -199,34 +171,6 @@ std::string database_impl::directory()
 void database_impl::verify()
 {
     library_->verify();
-}
-
-std::vector<playlist> database_impl::playlists()
-{
-    auto ids = library_->playlist().all_ids();
-    std::vector<playlist> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<playlist_impl>(library_, id));
-    }
-
-    return results;
-}
-
-std::vector<playlist> database_impl::playlists_by_name(const std::string& name)
-{
-    auto ids = library_->playlist().find_ids(name);
-    std::vector<playlist> results;
-    results.reserve(ids.size());
-
-    for (auto&& id : ids)
-    {
-        results.emplace_back(std::make_shared<playlist_impl>(library_, id));
-    }
-
-    return results;
 }
 
 void database_impl::remove_crate(crate cr)

--- a/src/djinterop/engine/v3/database_impl.hpp
+++ b/src/djinterop/engine/v3/database_impl.hpp
@@ -33,9 +33,6 @@ public:
     explicit database_impl(std::shared_ptr<engine_library> library);
 
     std::optional<djinterop::crate> crate_by_id(int64_t id) override;
-    std::vector<djinterop::crate> crates() override;
-    std::vector<djinterop::crate> crates_by_name(
-        const std::string& name) override;
     crate create_root_crate(const std::string& name) override;
     crate create_root_crate_after(
         const std::string& name, const crate& after) override;
@@ -46,8 +43,6 @@ public:
     track create_track(const track_snapshot& snapshot) override;
     std::string directory() override;
     void verify() override;
-    std::vector<playlist> playlists_by_name(const std::string& name) override;
-    std::vector<playlist> playlists() override;
     void remove_crate(djinterop::crate cr) override;
     void remove_playlist(const djinterop::playlist_impl& pl_base) override;
     void remove_track(djinterop::track tr) override;

--- a/src/djinterop/impl/database_impl.hpp
+++ b/src/djinterop/impl/database_impl.hpp
@@ -50,8 +50,6 @@ public:
     }
 
     virtual std::optional<crate> crate_by_id(int64_t id) = 0;
-    virtual std::vector<crate> crates() = 0;
-    virtual std::vector<crate> crates_by_name(const std::string& name) = 0;
     virtual playlist create_root_playlist(const std::string& name) = 0;
     virtual playlist create_root_playlist_after(
         const std::string& name, const playlist_impl& after) = 0;
@@ -61,9 +59,6 @@ public:
     virtual track create_track(const track_snapshot& snapshot) = 0;
     virtual std::string directory() = 0;
     virtual void verify() = 0;
-    virtual std::vector<playlist> playlists_by_name(
-        const std::string& name) = 0;
-    virtual std::vector<playlist> playlists() = 0;
     virtual void remove_crate(crate cr) = 0;
     virtual void remove_playlist(const playlist_impl& pl) = 0;
     virtual void remove_track(track tr) = 0;


### PR DESCRIPTION
Methods exposing crates and/or playlists at any arbitrary level of the hierarchy aren't really the right fit for the API.