### PR TITLE
Remove deprecated Ubuntu Focal build runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,6 @@ jobs:
 
       matrix:
         config: [
-          { os: ubuntu-20.04, c_compiler: gcc-10, cpp_compiler: g++-10 },
           { os: ubuntu-22.04, c_compiler: clang-14, cpp_compiler: clang++-14 },
           { os: ubuntu-22.04, c_compiler: clang-15, cpp_compiler: clang++-15 },
           { os: ubuntu-22.04, c_compiler: gcc-11, cpp_compiler: g++-11 },


### PR DESCRIPTION
See https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/