### PR TITLE
fix: failing tests due to missing high_res_waveform_data for v1 data

### DIFF
--- a/src/djinterop/engine/v1/engine_track_impl.cpp
+++ b/src/djinterop/engine/v1/engine_track_impl.cpp
@@ -244,6 +244,10 @@ high_res_waveform_data to_high_res_waveform_data(
     std::optional<double> sample_rate,
     const std::vector<waveform_entry>& waveform)
 {
+    if (!sample_count || !sample_rate)
+    {
+        return high_res_waveform_data{0};
+    }
     // Make the assumption that the client has respected the required number
     // of samples per entry when constructing the waveform.
     auto extents = util::calculate_high_resolution_waveform_extents(


### PR DESCRIPTION
A large number of v1 schema tests were previously failing because `to_high_res_waveform_data` assumed that the passed in snapshot had waveform data. This "fixes" this by adding a check just like `to_overview_waveform_data` that ensures that the snapshot actually contains a valid `sample_count` and `sample_rate`. If not, return an empty  `high_res_waveform_data` instance.