### PR TITLE
[CYGWIN][MINGW] Remove DJINTEROP_PUBLIC, enum doesn't export symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(libdjinterop
-        VERSION 0.28.0
+        VERSION 0.27.3
         DESCRIPTION "C++ library providing access to DJ record libraries")
 set(PROJECT_HOMEPAGE_URL "https://github.com/xsco/libdjinterop")
 

--- a/include/djinterop/engine/engine_schema.hpp
+++ b/include/djinterop/engine/engine_schema.hpp
@@ -28,7 +28,7 @@
 namespace djinterop::engine
 {
 /// Enumeration of Engine database schemas.
-enum class DJINTEROP_PUBLIC engine_schema
+enum class engine_schema
 {
     schema_1_6_0,
     schema_1_7_1,


### PR DESCRIPTION
I tried to build libdjinterop with both MinGW and Cygwin, but this error comes out:
```
include/djinterop/engine/engine_schema.hpp:31:29: error: ‘dllexport’ attribute ignored [-Werror=attributes]
   31 | enum class DJINTEROP_PUBLIC engine_schema
      |                             ^~~~~~~~~~~~~
```
In my opinion, this error is correct because an `enum` does not generate binary symbols, so GCC tells us that the attribute has no effect and the `-Werror` option handles it as an error.
I could not understand why it has been done here too because PR #142 doesn't write any information about the reasons of this change.
In my opinion, this attribute must be removed from that point.
Perhaps MSVC tolerates it, but a more strict compiler like GCC does not.
